### PR TITLE
Difficulty curve: pairing-biased spawns, level goals, isolated-tile indicator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1206,6 +1206,13 @@
   font-family: ui-monospace, Menlo, monospace;
 }
 
+.mode-status-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+
 .mode-status {
   font-family: ui-monospace, Menlo, monospace;
   font-size: 12px;

--- a/src/components/ModeStatusBar.tsx
+++ b/src/components/ModeStatusBar.tsx
@@ -4,6 +4,8 @@ type Props = {
   state: GameState;
 };
 
+type Banner = { className: string; text: string };
+
 function goalText(goal: LevelGoal, met: boolean): string {
   if (goal.kind === "chain-length") {
     const progress = `${goal.best}/${goal.target}`;
@@ -13,70 +15,73 @@ function goalText(goal: LevelGoal, met: boolean): string {
   return met ? `Goal: produce ${label} ✓` : `Goal: produce a ${label}`;
 }
 
-export function ModeStatusBar({ state }: Props) {
+function modeBanner(state: GameState): Banner | null {
   if (state.mode === "risingFloor" && state.modeState.kind === "risingFloor") {
     const { floor, movesToRaise } = state.modeState;
     if (movesToRaise <= 1) {
-      return (
-        <div className="mode-status mode-status-critical">
-          <span className="mode-status-hint">
-            Floor rises next move — clear your {floor}s! Queue will reset.
-          </span>
-        </div>
-      );
+      return {
+        className: "mode-status mode-status-critical",
+        text: `Floor rises next move — clear your ${floor}s! Queue will reset.`,
+      };
     }
     if (movesToRaise <= 3) {
-      return (
-        <div className="mode-status mode-status-warn">
-          <span className="mode-status-hint">
-            Floor rises in {movesToRaise} — clear your {floor}s
-          </span>
-        </div>
-      );
+      return {
+        className: "mode-status mode-status-warn",
+        text: `Floor rises in ${movesToRaise} — clear your ${floor}s`,
+      };
     }
     return null;
   }
-
   if (state.mode === "wilds" && state.modeState.kind === "wilds") {
     const { movesUntilBeast, frenzyRemaining, activeBeastIds } = state.modeState;
     if (frenzyRemaining > 0) {
-      return (
-        <div className="mode-status mode-status-wilds-frenzy">
-          <span className="mode-status-hint">
-            Wild Frenzy · all spawns wild for {frenzyRemaining} more · 1.5× chains
-          </span>
-        </div>
-      );
+      return {
+        className: "mode-status mode-status-wilds-frenzy",
+        text: `Wild Frenzy · all spawns wild for ${frenzyRemaining} more · 1.5× chains`,
+      };
     }
     if (activeBeastIds.length > 0) {
-      return (
-        <div className="mode-status mode-status-wilds">
-          <span className="mode-status-hint">
-            {activeBeastIds.length} beast{activeBeastIds.length > 1 ? "s" : ""} on the hunt — chain 3+ to defeat
-          </span>
-        </div>
-      );
+      return {
+        className: "mode-status mode-status-wilds",
+        text: `${activeBeastIds.length} beast${activeBeastIds.length > 1 ? "s" : ""} on the hunt — chain 3+ to defeat`,
+      };
     }
     if (movesUntilBeast <= 2) {
-      return (
-        <div className="mode-status mode-status-critical">
-          <span className="mode-status-hint">
-            Beast spawns {movesUntilBeast === 1 ? "next move" : `in ${movesUntilBeast}`}
-          </span>
-        </div>
-      );
+      return {
+        className: "mode-status mode-status-critical",
+        text: `Beast spawns ${movesUntilBeast === 1 ? "next move" : `in ${movesUntilBeast}`}`,
+      };
     }
     return null;
   }
-
-  if (state.levelGoal) {
-    const met = state.levelGoalMet;
-    return (
-      <div className={`mode-status ${met ? "mode-status-goal-met" : "mode-status-goal"}`}>
-        <span className="mode-status-hint">{goalText(state.levelGoal, met)}</span>
-      </div>
-    );
-  }
-
   return null;
+}
+
+function goalBanner(state: GameState): Banner | null {
+  if (!state.levelGoal) return null;
+  const met = state.levelGoalMet;
+  return {
+    className: `mode-status ${met ? "mode-status-goal-met" : "mode-status-goal"}`,
+    text: goalText(state.levelGoal, met),
+  };
+}
+
+export function ModeStatusBar({ state }: Props) {
+  const mode = modeBanner(state);
+  const goal = goalBanner(state);
+  if (!mode && !goal) return null;
+  return (
+    <div className="mode-status-stack">
+      {mode && (
+        <div className={mode.className}>
+          <span className="mode-status-hint">{mode.text}</span>
+        </div>
+      )}
+      {goal && (
+        <div className={goal.className}>
+          <span className="mode-status-hint">{goal.text}</span>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -249,7 +249,7 @@ function buildFinalState(state: GameState, ctx: BuildFinalStateCtx): GameState {
   );
 
   const nextGoal: LevelGoal | null = leveledUp
-    ? generateGoalForLevel(ctx.targets.nextLevels)
+    ? generateGoalForLevel(ctx.targets.nextLevels + 1)
     : updatedGoal;
   const nextGoalMet = leveledUp ? false : updatedGoalMet;
 
@@ -374,7 +374,7 @@ export function newGame(
     ratchetInterval: Math.max(1, ratchetInterval),
     undoStack: [],
     undoCharges: UNDO_INITIAL_CHARGES,
-    levelGoal: null,
+    levelGoal: generateGoalForLevel(1),
     levelGoalMet: false,
   };
 }


### PR DESCRIPTION
## User Task

Player feedback identified a flat difficulty curve driven by random cascade refills, a one-dimensional Floor mechanic, and constant mental bookkeeping to find chain starts. The user asked to plan and implement changes that give the game a real difficulty curve and reduce the cognitive load on the player.

## Work Completed

Three changes shipped, all functional and verified in the browser preview:

1. **Pairing-biased spawn system** (level-scaled): new `pairingBiasWeights()` and `singletonCount()` in `src/game/spawn.ts`; `pairingStrength` parameter threaded through `sampleByAlgo`, `makeSpawnQueue`, `takeSpawn`, and `refillFromQueue`. `levelPairingStrength()` in `engine.ts` ramps the bias from 2.0× at levels 0–2 down to 0 by level 7+. Only affects the `weighted` algo; `antiPair`/`adversarial` are untouched.
2. **Level goals**: `LevelGoal` type added to `types.ts` (`chain-length` | `produce-value`); `generateGoalForLevel()` cycles through the two kinds with tier scaling. Progress is tracked per move, met goals award +1 bonus undo charge at level-up (cap raised to `UNDO_MAX_CHARGES + 1`). Goal renders in `ModeStatusBar` from the very first move and refreshes on level-up.
3. **Isolated tile indicator**: `findIsolatedTiles()` in `rules.ts` flags tiles with no equal-value orthogonal neighbor. Board renders them at 0.55 opacity (cleared during drag so it doesn't interfere with chain selection).

Files touched: `spawn.ts`, `grid.ts`, `engine.ts`, `types.ts`, `rules.ts`, `scenarios.ts`, `Board.tsx`, `Tile.tsx`, `ModeStatusBar.tsx`, `App.css`.

## Assumptions

- The pairing bias should be **automatic default behavior** of the `weighted` algo, not a setting or mode. The feedback framed it as the difficulty curve of the game, not an opt-in assist. Asked the user mid-implementation; they did not push back.
- Goal cadence (`chain-length` / `produce-value` alternating, tier scaling every 4 levels) was chosen for simplicity. The feedback suggested "stacked" goals at higher levels; not implemented in this pass.
- Goal semantics: the goal shown while on level N represents what to achieve before reaching N+1. Met = bonus at the next level-up.
- The bonus reward is +1 undo charge (capped at 4). Not a score multiplier, since undo charges are the existing scarce resource the player feels.

## Decisions

- **Goal initialization at game start**: first version had `levelGoal: null` until first level-up, which meant the goal never appeared for new players (the user caught this). Fixed by initializing with `generateGoalForLevel(1)` in `newGame()` and regenerating with `nextLevels + 1` on level-up.
- **`ModeStatusBar` refactor**: original early-`return null` for `risingFloor`/`wilds` modes when no urgent banner was active suppressed the goal entirely. Refactored into `modeBanner()` + `goalBanner()` helpers rendered in a vertical stack so both can show simultaneously.
- **Singleton-pairing semantics**: chose to count board tiles whose value equals the candidate spawn AND have no orthogonal same-value neighbor. Multiplicative weight boost (`base * (1 + strength * count)`) rather than divisive (which can blow up near zero).
- **Skipped from the original plan**: chain-rule relaxation at low levels ("equal, double, or half") and a stacked / multi-objective goal layer. These were in the player's full feedback but not in the plan I wrote.

## Questions / Concerns

- **Difficulty tuning is unmeasured.** The bias values (2.0 → 1.0 → 0.5 → 0) are first-cut numbers. Worth running through the existing harness/sweep tooling (`scripts/sweep-config.ts`) to confirm they actually produce the intended curve and don't make level 0–2 trivial.
- **Goal-progression repetition.** With current math, levels 3 and 5 both target "chain length 5", and levels 4 and 6 both target "produce 64". Not broken, but feels flat across that band. Consider a different cycle or scaling formula.
- **No test coverage added.** The chain/spawn/engine modules likely have unit tests; I didn't add coverage for `pairingBiasWeights`, `findIsolatedTiles`, or the goal lifecycle. Should be added before this lands as canonical behavior.
- **History hygiene**: the bulk of the feature work is in the `Initial commit` on main (committed before the branch was cut). This PR's diff only shows the recent goal-init + `ModeStatusBar` fixes. To truly isolate the feature work to this branch we'd need to rewrite the initial commit and force-push — flagged but not done.
- **Telemetry / Dev Panel.** No dev-panel toggle exposed for `pairingStrength` or for disabling level goals. Tuning via UI would help iteration; right now changes require code edits.

## Scope

**Original plan scope** (the approved plan file):
1. Pairing-biased spawn system with level scaling
2. Level goals with progression tracking and bonus reward
3. Isolated tile indicator

**Did the changes align to the scope?** Yes — all three planned changes shipped end-to-end.

**Scope creep?** Minor. The `ModeStatusBar` refactor (mode banner + goal banner stack) wasn't in the plan; it was forced by a bug discovered during verification. Justifiable: the plan was dependent on the goal actually rendering, and the existing component prevented that.

**Scope reduced?** Yes, deliberately. The player's full feedback included additional levers I didn't plan or build:
- Chain-rule variants per difficulty ("equal, double, or half" at easy, etc.)
- Stacked / competing goals at higher levels
- "Highlight all currently-playable starting tiles on hover" (the isolated-tile indicator addresses an inverse of this, but doesn't show forward chain reachability)
- Tile-placement agency (per-level swaps, rotates, deletes)
- Scoring changes that reward escalating chains over equal chains

These are larger surface-area changes deserving their own plans rather than being smuggled into this one.
