### PR TITLE
Set up Claude agent foundations (CLAUDE.md, README, settings, CI)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint)",
+      "Bash(npm run build)",
+      "Bash(npm run harness:*)",
+      "Bash(npm run bench:*)",
+      "Bash(npm run sweep:*)",
+      "Bash(npm run baseline:*)",
+      "Bash(npm run study:*)",
+      "Bash(npm run replay:*)",
+      "Bash(npm run compare:*)",
+      "Bash(npm run power:*)",
+      "Bash(npm run describe:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(node --version)",
+      "Bash(npx tsc --noEmit:*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          { "type": "command",
+            "command": "test -d node_modules || npm ci --no-audit --no-fund" }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '22', cache: 'npm' }
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+2248 chain-merge game — a single-player puzzle where chains of equal-rank tiles collapse into the next rank. React 19 + Vite 8 + TypeScript (strict). Targets Node 22.
+
+The repo bundles two things: the playable game (`src/`) and a balance-simulation **harness** (`scripts/`) that runs deterministic bot games and emits replayable JSON manifests.
+
+## Layout
+
+- `src/game/` — pure engine. Core files: `engine.ts`, `bot.ts`, `spawn.ts`, `rules.ts`, `scenarios.ts`. Determinism is funnelled through `rng.ts` so that any (seed, args) pair produces a bit-exact game.
+- `src/components/`, `src/views/`, `src/hooks/` — UI layer. Entry point is `src/App.tsx`.
+- `scripts/` — harness dispatcher (`harness.ts`), shared lib (`_lib.ts`), and named studies under `scripts/studies/`. All harness output JSON is written to `dist/`.
+- `baselines/` — committed reference perf manifests used for drift detection.
+- `docs/harness/` — harness usage (`README.md`) and stats methodology (`STATS.md`).
+
+## Common commands
+
+- `npm run dev` — Vite dev server. `.claude/launch.json` pins port **5180** with `--strictPort`; do not change.
+- `npm run lint` — `eslint .`
+- `npm run build` — `tsc -b && vite build`
+
+Harness aliases (each is `npx tsx scripts/harness.ts <subcommand>`):
+
+- `npm run harness` — print help and list studies.
+- `npm run bench` — per-mode benchmark across spawn algos.
+- `npm run sweep` — Cartesian sweep over board × pool.
+- `npm run baseline` — capture `baselines/perf-<id>.json`.
+- `npm run study -- <name>` — run a registered study from `scripts/studies/`.
+- `npm run replay -- <manifest.json>` — bit-exact reproduction of a past run.
+- `npm run compare -- <a.json> <b.json>` — paired/independent delta CIs (auto-detected).
+- `npm run power` — required N for an MDE given variance.
+- `npm run describe -- <topic>` — agent-facing JSON schema.
+
+## Agent-facing schema
+
+`npm run describe -- all` dumps a single JSON object describing **metrics**, **bots**, **modes**, and **algos**. Use this before adding new harness flags or interpreting manifest fields — it is the source of truth for what the harness exposes.
+
+## Conventions
+
+- **No comments unless the *why* is non-obvious.** Identifiers carry intent; reserve comments for invariants, surprises, and workarounds.
+- **Manifests are bit-exactly replayable.** Every harness output carries a `gitSha` + `seedList` envelope; `harness replay <manifest>` reconstructs argv from those fields. Don't add non-deterministic state to manifests.
+- **Never edit `baselines/*` without an explicit balance-change rationale.** Baselines are the drift-detection ground truth; rewriting them silently invalidates all open comparisons.
+
+## Don'ts
+
+- No features beyond the task at hand.
+- No backwards-compatibility shims — this is a private game, just change the code.
+- Never run sweeps with `--allow-long` without explicit user confirmation; the default `--max-games 5000` guardrail exists for a reason.
+
+## Pointer
+
+TODO: deep domain context (bot strategy, mode design, study catalogue) lives in `docs/AGENTS.md` — that file lands in #2.

--- a/README.md
+++ b/README.md
@@ -1,73 +1,28 @@
-# React + TypeScript + Vite
+# 2248
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A single-player chain-merge puzzle: drag through paths of equal-rank tiles to collapse them into the next rank, build chains, and survive as long as the spawn pool keeps escalating. Built with React 19, Vite 8, and TypeScript (strict).
 
-Currently, two official plugins are available:
+## Quick start
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The dev server runs on port **5180** (pinned via `.claude/launch.json`).
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Project layout
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+- `src/game/` — pure, deterministic engine (rules, spawn algos, bot, scenarios, RNG).
+- `src/components/`, `src/views/`, `src/hooks/`, `src/App.tsx` — UI layer.
+- `scripts/` — balance-simulation harness. The dispatcher is `scripts/harness.ts`; named studies live under `scripts/studies/`.
+- `baselines/` — committed reference perf manifests for drift detection.
+- `docs/harness/` — harness usage and stats methodology.
+
+## Eval harness
+
+The harness runs deterministic bot games and emits replayable JSON manifests. See [`docs/harness/README.md`](docs/harness/README.md) for the full CLI surface and [`docs/harness/STATS.md`](docs/harness/STATS.md) for how to read confidence intervals and paired-bootstrap deltas.
+
+## Working with Claude Code
+
+If you're contributing as (or with) an agent, start at [`CLAUDE.md`](CLAUDE.md) — it covers the layout, conventions, and don'ts that aren't obvious from the source alone.


### PR DESCRIPTION
## Summary

Closes #1.

- Add `CLAUDE.md` so a fresh Claude Code session loads project memory automatically — covers layout, commands, harness aliases, conventions (no comments unless the *why* is non-obvious; manifests are bit-exactly replayable; never edit `baselines/*` without rationale), and don'ts. Includes a TODO pointer to `docs/AGENTS.md` (lands in #2).
- Replace the default Vite scaffold `README.md` with a project-specific one: game pitch, quick start, layout, pointer to `docs/harness/README.md` and `CLAUDE.md`.
- Add `.claude/settings.json` with the issue's verbatim permissions allowlist (so routine `npm run lint` / `git diff` / harness commands skip prompts) and a `SessionStart` hook that runs `npm ci` if `node_modules` is missing (for Claude on the web).
- Add `.github/workflows/ci.yml` with the issue's verbatim YAML — Node 22, `npm ci → lint → build` on push and PR.

## Heads-up: CI will be red on this PR

`npm run lint` fails with **30 pre-existing errors** in files this PR does not touch (`scripts/*.ts`, `src/App.tsx`, `src/components/*.tsx`, `src/game/engine.ts`, `src/game/modes/boost.ts`, `src/game/modifiers/*.ts`). The lint debt is pre-existing — this PR just makes it visible by adding the CI gate the issue asked for.

Tracked in #4 with a triage of mechanical vs. judgment fixes. Recommended sequence: merge this PR (red CI), then land #4 to turn CI green.

## Test plan

- [x] `npm run build` succeeds locally.
- [x] `.github/workflows/ci.yml` parses as valid YAML.
- [x] `.claude/settings.json` parses as valid JSON.
- [ ] Confirm a fresh Claude Code session in the repo loads `CLAUDE.md` automatically.
- [ ] Confirm `npm run lint` runs without a permission prompt under the new `.claude/settings.json`.
- [ ] After #4 lands, CI on the next PR turns green.

https://claude.ai/code/session_01F7c3HjABy4sJnotxWV1A19

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7c3HjABy4sJnotxWV1A19)_