### PR TITLE
Fix mechanical lint errors in scripts/ and tighten eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,12 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+    },
   },
 ])

--- a/scripts/_lib.ts
+++ b/scripts/_lib.ts
@@ -6,7 +6,7 @@
 
 import { execSync } from "node:child_process";
 import os from "node:os";
-import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -454,11 +454,10 @@ export function loadBaselineGamesPerSec(): number | null {
   try {
     const dir = "baselines";
     if (!existsSync(dir)) return null;
-    const fs = require("node:fs");
-    const files = fs.readdirSync(dir).filter((f: string) => f.endsWith(".json")).sort();
+    const files = readdirSync(dir).filter((f) => f.endsWith(".json")).sort();
     if (files.length === 0) return null;
     const latest = files[files.length - 1];
-    const data = JSON.parse(fs.readFileSync(`${dir}/${latest}`, "utf8"));
+    const data = JSON.parse(readFileSync(`${dir}/${latest}`, "utf8"));
     if (data.schema !== "harness-perf-baseline") return null;
     return typeof data.overallGamesPerSec === "number" ? data.overallGamesPerSec : null;
   } catch {

--- a/scripts/compare.ts
+++ b/scripts/compare.ts
@@ -16,9 +16,17 @@ import {
   seedsMatch, pairedDeltaCI, independentDeltaCI, mean as meanOf, printTable,
 } from "./_lib";
 
+type RunShape = { seed: number; [metric: string]: number };
+type SummaryShape = {
+  mode: string;
+  algo: string;
+  policy: string;
+  runs: RunShape[];
+  seedList?: number[];
+};
 type Manifest = {
   manifest?: { schema?: string };
-  summaries?: any[];
+  summaries?: SummaryShape[];
   // Studies wrap differently; we'll just look for `summaries` for now.
 };
 
@@ -26,17 +34,17 @@ type Cell = {
   mode: string;
   algo: string;
   policy: string;
-  runs: Array<{ seed: number; moves: number; peak: number; score: number; levelsCleared: number; modeMetric: number; chainLenSum: number }>;
+  runs: RunShape[];
   seedList?: number[];
 };
 
 function loadCells(path: string): Cell[] {
   const raw = JSON.parse(readFileSync(path, "utf8")) as Manifest;
   if (!raw.summaries) throw new Error(`${path}: no .summaries (only benchmark manifests are supported by compare for now).`);
-  return raw.summaries.map((s: any) => ({
+  return raw.summaries.map((s) => ({
     mode: s.mode, algo: s.algo, policy: s.policy,
     runs: s.runs,
-    seedList: s.seedList ?? s.runs?.map((r: any) => r.seed),
+    seedList: s.seedList ?? s.runs?.map((r) => r.seed),
   }));
 }
 
@@ -111,8 +119,8 @@ export function main(argv: string[]): void {
     const paired = seedsMatch(aSeeds, bSeeds);
     if (!paired) unpairedCount++;
     for (const m of metrics) {
-      const aVals = a.runs.map((r) => (r as any)[m] as number);
-      const bVals = b.runs.map((r) => (r as any)[m] as number);
+      const aVals = a.runs.map((r) => r[m]);
+      const bVals = b.runs.map((r) => r[m]);
       let delta: number, halfWidth: number, low: number, high: number;
       if (paired) {
         const r = pairedDeltaCI(aVals, bVals);

--- a/scripts/harness.ts
+++ b/scripts/harness.ts
@@ -25,8 +25,7 @@ import { main as baselineMain } from "./baseline";
 import { main as compareMain } from "./compare";
 import { main as powerMain } from "./power";
 
-const COMMANDS = ["bench", "sweep", "baseline", "study", "replay", "compare", "power", "describe", "help"] as const;
-type Command = (typeof COMMANDS)[number];
+type Command = "bench" | "sweep" | "baseline" | "study" | "replay" | "compare" | "power" | "describe" | "help";
 
 function help(): void {
   console.log(`

--- a/scripts/power.ts
+++ b/scripts/power.ts
@@ -22,8 +22,8 @@ export function main(argv: string[]): void {
   const mdePct = f.num("--mde", 5, { min: 0.01 });
   const oneSample = f.has("--one-sample");
 
-  let manualMean = f.get("--mean") !== undefined ? f.num("--mean", 0) : NaN;
-  let manualStd = f.get("--stddev") !== undefined ? f.num("--stddev", 0, { min: 0 }) : NaN;
+  const manualMean = f.get("--mean") !== undefined ? f.num("--mean", 0) : NaN;
+  const manualStd = f.get("--stddev") !== undefined ? f.num("--stddev", 0, { min: 0 }) : NaN;
 
   if (manifestPath) {
     const raw = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -32,8 +32,8 @@ export function main(argv: string[]): void {
     console.log(`\n  Power analysis — metric=${metric}, MDE=${mdePct}%, ${oneSample ? "one" : "two"}-sample\n`);
     console.log(`    cell                                  mean       stddev    needed N`);
     console.log(`    ------------------------------------  ---------  --------  --------`);
-    for (const s of summaries) {
-      const xs = (s.runs as any[]).map((r) => r[metric] as number);
+    for (const s of summaries as Array<{ mode: string; algo: string; policy: string; runs: Array<Record<string, number>> }>) {
+      const xs = s.runs.map((r) => r[metric]);
       const m = meanOf(xs);
       const sd = stddevOf(xs);
       const mde = Math.abs(m) * (mdePct / 100);

--- a/scripts/studies/algo-audit.ts
+++ b/scripts/studies/algo-audit.ts
@@ -15,7 +15,7 @@ import { sweep, deterministicSeeds } from "../../src/game/bot";
 import type { BenchmarkSummary } from "../../src/game/bot";
 import { randomSeed } from "../../src/game/rng";
 import {
-  parseFlags, fmtNum, fmtCI, fmtProportionCI,
+  parseFlags, fmtCI, fmtProportionCI,
   envelope, reconstructCommand, writeJSON, isMainModule,
   checkGuardrails, estimateRuntimeMs, DEFAULT_MAX_GAMES,
 } from "../_lib";


### PR DESCRIPTION
## Summary

Refs #4 — clears Buckets 1 and 2 (18 of 30 lint errors). The remaining 12 are Bucket 3 (React purity/refs/set-state-in-effect), which need actual refactoring and will land in a separate PR.

### Bucket 1 — `scripts/` mechanical (11 errors)
- `scripts/_lib.ts:457` — replace `require("node:fs")` with the existing ES import (added `readdirSync`/`readFileSync` to the import list).
- `scripts/compare.ts` — replace 5× `any` with structural `RunShape`/`SummaryShape` types. `RunShape` uses an index signature (`[metric: string]: number`) so dynamic metric access (`r[m]`) stays type-safe.
- `scripts/harness.ts:28` — drop the runtime `COMMANDS as const` array; the `Command` type is declared directly as a string union (the array was unused at runtime).
- `scripts/power.ts:25,26,36` — `let` → `const` for `manualMean`/`manualStd`; tighten the `summaries.runs` cast to a typed shape instead of `any`.
- `scripts/studies/algo-audit.ts:18` — drop unused `fmtNum` import.

### Bucket 2 — eslint config tweak (7 errors auto-cleared)
- `eslint.config.js` — add `argsIgnorePattern: '^_'` (plus `varsIgnorePattern` and `caughtErrorsIgnorePattern`) to the `@typescript-eslint/no-unused-vars` rule. The codebase already uses `_`-prefix to signal intentionally-unused parameters; the eslint config now honors that convention. Auto-clears `_prevStack`/`_prevCharges` in `engine.ts`, `_b`/`_e` in `modes/boost.ts`, and `_m` in both `modifiers/ice.ts` and `modifiers/lock.ts`.

## Test plan

- [x] `npm run lint` — went from **30 errors → 12 errors** (only Bucket 3 React rules remain).
- [x] `npm run build` — clean.
- [x] No behavior change: `compare.ts` and `power.ts` already accessed run fields by string-indexed lookup; the new `Record<string, number>` / index-signature types describe the same access pattern, just typed properly.

https://claude.ai/code/session_01F7c3HjABy4sJnotxWV1A19

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7c3HjABy4sJnotxWV1A19)_