### PR TITLE
Fix React purity, ref-during-render, and setState-in-effect lint errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,12 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+    },
   },
 ])

--- a/scripts/_lib.ts
+++ b/scripts/_lib.ts
@@ -6,7 +6,7 @@
 
 import { execSync } from "node:child_process";
 import os from "node:os";
-import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -454,11 +454,10 @@ export function loadBaselineGamesPerSec(): number | null {
   try {
     const dir = "baselines";
     if (!existsSync(dir)) return null;
-    const fs = require("node:fs");
-    const files = fs.readdirSync(dir).filter((f: string) => f.endsWith(".json")).sort();
+    const files = readdirSync(dir).filter((f) => f.endsWith(".json")).sort();
     if (files.length === 0) return null;
     const latest = files[files.length - 1];
-    const data = JSON.parse(fs.readFileSync(`${dir}/${latest}`, "utf8"));
+    const data = JSON.parse(readFileSync(`${dir}/${latest}`, "utf8"));
     if (data.schema !== "harness-perf-baseline") return null;
     return typeof data.overallGamesPerSec === "number" ? data.overallGamesPerSec : null;
   } catch {

--- a/scripts/compare.ts
+++ b/scripts/compare.ts
@@ -16,9 +16,17 @@ import {
   seedsMatch, pairedDeltaCI, independentDeltaCI, mean as meanOf, printTable,
 } from "./_lib";
 
+type RunShape = { seed: number; [metric: string]: number };
+type SummaryShape = {
+  mode: string;
+  algo: string;
+  policy: string;
+  runs: RunShape[];
+  seedList?: number[];
+};
 type Manifest = {
   manifest?: { schema?: string };
-  summaries?: any[];
+  summaries?: SummaryShape[];
   // Studies wrap differently; we'll just look for `summaries` for now.
 };
 
@@ -26,17 +34,17 @@ type Cell = {
   mode: string;
   algo: string;
   policy: string;
-  runs: Array<{ seed: number; moves: number; peak: number; score: number; levelsCleared: number; modeMetric: number; chainLenSum: number }>;
+  runs: RunShape[];
   seedList?: number[];
 };
 
 function loadCells(path: string): Cell[] {
   const raw = JSON.parse(readFileSync(path, "utf8")) as Manifest;
   if (!raw.summaries) throw new Error(`${path}: no .summaries (only benchmark manifests are supported by compare for now).`);
-  return raw.summaries.map((s: any) => ({
+  return raw.summaries.map((s) => ({
     mode: s.mode, algo: s.algo, policy: s.policy,
     runs: s.runs,
-    seedList: s.seedList ?? s.runs?.map((r: any) => r.seed),
+    seedList: s.seedList ?? s.runs?.map((r) => r.seed),
   }));
 }
 
@@ -111,8 +119,8 @@ export function main(argv: string[]): void {
     const paired = seedsMatch(aSeeds, bSeeds);
     if (!paired) unpairedCount++;
     for (const m of metrics) {
-      const aVals = a.runs.map((r) => (r as any)[m] as number);
-      const bVals = b.runs.map((r) => (r as any)[m] as number);
+      const aVals = a.runs.map((r) => r[m]);
+      const bVals = b.runs.map((r) => r[m]);
       let delta: number, halfWidth: number, low: number, high: number;
       if (paired) {
         const r = pairedDeltaCI(aVals, bVals);

--- a/scripts/harness.ts
+++ b/scripts/harness.ts
@@ -25,8 +25,7 @@ import { main as baselineMain } from "./baseline";
 import { main as compareMain } from "./compare";
 import { main as powerMain } from "./power";
 
-const COMMANDS = ["bench", "sweep", "baseline", "study", "replay", "compare", "power", "describe", "help"] as const;
-type Command = (typeof COMMANDS)[number];
+type Command = "bench" | "sweep" | "baseline" | "study" | "replay" | "compare" | "power" | "describe" | "help";
 
 function help(): void {
   console.log(`

--- a/scripts/power.ts
+++ b/scripts/power.ts
@@ -22,8 +22,8 @@ export function main(argv: string[]): void {
   const mdePct = f.num("--mde", 5, { min: 0.01 });
   const oneSample = f.has("--one-sample");
 
-  let manualMean = f.get("--mean") !== undefined ? f.num("--mean", 0) : NaN;
-  let manualStd = f.get("--stddev") !== undefined ? f.num("--stddev", 0, { min: 0 }) : NaN;
+  const manualMean = f.get("--mean") !== undefined ? f.num("--mean", 0) : NaN;
+  const manualStd = f.get("--stddev") !== undefined ? f.num("--stddev", 0, { min: 0 }) : NaN;
 
   if (manifestPath) {
     const raw = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -32,8 +32,8 @@ export function main(argv: string[]): void {
     console.log(`\n  Power analysis — metric=${metric}, MDE=${mdePct}%, ${oneSample ? "one" : "two"}-sample\n`);
     console.log(`    cell                                  mean       stddev    needed N`);
     console.log(`    ------------------------------------  ---------  --------  --------`);
-    for (const s of summaries) {
-      const xs = (s.runs as any[]).map((r) => r[metric] as number);
+    for (const s of summaries as Array<{ mode: string; algo: string; policy: string; runs: Array<Record<string, number>> }>) {
+      const xs = s.runs.map((r) => r[metric]);
       const m = meanOf(xs);
       const sd = stddevOf(xs);
       const mde = Math.abs(m) * (mdePct / 100);

--- a/scripts/studies/algo-audit.ts
+++ b/scripts/studies/algo-audit.ts
@@ -15,7 +15,7 @@ import { sweep, deterministicSeeds } from "../../src/game/bot";
 import type { BenchmarkSummary } from "../../src/game/bot";
 import { randomSeed } from "../../src/game/rng";
 import {
-  parseFlags, fmtNum, fmtCI, fmtProportionCI,
+  parseFlags, fmtCI, fmtProportionCI,
   envelope, reconstructCommand, writeJSON, isMainModule,
   checkGuardrails, estimateRuntimeMs, DEFAULT_MAX_GAMES,
 } from "../_lib";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
   const [settings, setSettings] = useSettingsPersistence();
   const ctrl = useGameController(settings, setSettings);
   const [devOpen, setDevOpen] = useState(false);
-  const [now, setNow] = useState(Date.now());
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 500);

--- a/src/components/DevPanel.tsx
+++ b/src/components/DevPanel.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import type { GameMode, GameState, SpawnAlgo, Telemetry } from "../game/types";
 import { ALL_ALGOS, ALL_MODES, MODE_LABELS, algoUsesSoftness, algoUsesStrength } from "../game/types";
-import { appendRun, clearRuns, readRuns, summarize } from "../game/runLog";
+import { appendRun, clearRuns, summarize } from "../game/runLog";
 import type { RunEntry } from "../game/runLog";
 import { benchmark, sweep } from "../game/bot";
 import type { BenchmarkSummary, BotPolicy } from "../game/bot";
@@ -770,5 +770,3 @@ function Row({
     </div>
   );
 }
-
-export { readRuns };

--- a/src/components/FlyingTile.tsx
+++ b/src/components/FlyingTile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useId, useMemo } from "react";
 import type { Coord } from "../game/types";
 import { CELL_SIZE, cellOrigin } from "./boardLayout";
 import { ANIM } from "./animationTiming";
@@ -15,8 +15,7 @@ type Props = {
 export function FlyingTile({ value, waypoints, delay, onArrive }: Props) {
   const { bg, fg } = tileColors(value);
   const label = value >= 1024 ? formatCompact(value) : String(value);
-  const animNameRef = useRef(`fly-${Math.random().toString(36).slice(2, 9)}`);
-  const styleRef = useRef<HTMLStyleElement | null>(null);
+  const animName = `fly-${useId().replace(/:/g, "-")}`;
 
   const keyframesCss = useMemo(() => {
     if (waypoints.length === 0) return "";
@@ -49,14 +48,13 @@ export function FlyingTile({ value, waypoints, delay, onArrive }: Props) {
         `${pct.toFixed(2)}% { transform: translate(${x}px, ${y}px) scaleX(${scaleX.toFixed(3)}) scaleY(${scaleY.toFixed(3)}); opacity: ${isLast ? 0 : 1}; }`
       );
     }
-    return `@keyframes ${animNameRef.current} { ${frames.join(" ")} }`;
-  }, [waypoints]);
+    return `@keyframes ${animName} { ${frames.join(" ")} }`;
+  }, [waypoints, animName]);
 
   useEffect(() => {
     const style = document.createElement("style");
     style.textContent = keyframesCss;
     document.head.appendChild(style);
-    styleRef.current = style;
     return () => {
       style.remove();
     };
@@ -71,7 +69,7 @@ export function FlyingTile({ value, waypoints, delay, onArrive }: Props) {
 
   const start = waypoints[0];
   const startOrigin = cellOrigin(start.r, start.c);
-  const animStyle = `${animNameRef.current} ${ANIM.flyPerTile}ms cubic-bezier(.5,.1,.4,1) ${delay}ms forwards`;
+  const animStyle = `${animName} ${ANIM.flyPerTile}ms cubic-bezier(.5,.1,.4,1) ${delay}ms forwards`;
 
   return (
     <>

--- a/src/components/LevelUpOverlay.tsx
+++ b/src/components/LevelUpOverlay.tsx
@@ -7,22 +7,21 @@ type Props = {
 // Non-blocking celebration. Shows when `lastLevelUp` changes to a non-null value
 // with a different level than the last one we rendered. Auto-dismisses.
 export function LevelUpOverlay({ lastLevelUp }: Props) {
-  const [visible, setVisible] = useState<{ level: number; target: number } | null>(null);
+  const [hideAtLevel, setHideAtLevel] = useState<number | null>(null);
 
   useEffect(() => {
     if (!lastLevelUp) return;
-    setVisible(lastLevelUp);
-    const t = setTimeout(() => setVisible(null), 1500);
+    const t = setTimeout(() => setHideAtLevel(lastLevelUp.level), 1500);
     return () => clearTimeout(t);
-  }, [lastLevelUp?.level, lastLevelUp?.target]);
+  }, [lastLevelUp]);
 
-  if (!visible) return null;
+  if (!lastLevelUp || lastLevelUp.level === hideAtLevel) return null;
   return (
-    <div className="levelup-overlay" key={`${visible.level}-${visible.target}`}>
+    <div className="levelup-overlay" key={`${lastLevelUp.level}-${lastLevelUp.target}`}>
       <div className="levelup-card">
         <div className="levelup-label">Level</div>
-        <div className="levelup-level">{visible.level}</div>
-        <div className="levelup-target">{visible.target} reached</div>
+        <div className="levelup-level">{lastLevelUp.level}</div>
+        <div className="levelup-target">{lastLevelUp.target} reached</div>
       </div>
     </div>
   );

--- a/src/components/MergeBurst.tsx
+++ b/src/components/MergeBurst.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useMemo } from "react";
 import { tileColors } from "./palette";
 
 type Props = {
@@ -13,14 +13,11 @@ type Particle = { dx: number; dy: number; size: number };
 
 export function MergeBurst({ cx, cy, value }: Props) {
   const { fg } = tileColors(value);
-  const instanceId = useRef(`burst-${Math.random().toString(36).slice(2, 9)}`);
+  const id = `burst-${useId().replace(/:/g, "-")}`;
 
-  // Deterministic particle layout, computed once
-  const particlesRef = useRef<Particle[] | null>(null);
-  if (!particlesRef.current) {
-    particlesRef.current = Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+  const particles = useMemo<Particle[]>(() => {
+    return Array.from({ length: PARTICLE_COUNT }, (_, i) => {
       const angle = (i / PARTICLE_COUNT) * 2 * Math.PI;
-      // Varied distances without Math.random for determinism across renders
       const dist = 35 + (i * 3.7) % 35;
       return {
         dx: Math.cos(angle) * dist,
@@ -28,10 +25,7 @@ export function MergeBurst({ cx, cy, value }: Props) {
         size: 4 + (i % 5),
       };
     });
-  }
-
-  const particles = particlesRef.current;
-  const id = instanceId.current;
+  }, []);
 
   useEffect(() => {
     const rules = particles.map((p, i) => `
@@ -44,7 +38,7 @@ export function MergeBurst({ cx, cy, value }: Props) {
     style.textContent = rules.join("\n");
     document.head.appendChild(style);
     return () => { style.remove(); };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, particles]);
 
   return (
     <>

--- a/src/components/TrophyFlash.tsx
+++ b/src/components/TrophyFlash.tsx
@@ -5,21 +5,20 @@ type Props = {
 };
 
 export function TrophyFlash({ flash }: Props) {
-  const [visible, setVisible] = useState<{ value: number; movesAt: number } | null>(null);
+  const [hideAtMoves, setHideAtMoves] = useState<number | null>(null);
 
   useEffect(() => {
     if (!flash) return;
-    setVisible(flash);
-    const t = setTimeout(() => setVisible(null), 1500);
+    const t = setTimeout(() => setHideAtMoves(flash.movesAt), 1500);
     return () => clearTimeout(t);
-  }, [flash?.value, flash?.movesAt]);
+  }, [flash]);
 
-  if (!visible) return null;
+  if (!flash || flash.movesAt === hideAtMoves) return null;
   return (
-    <div className="trophy-flash" key={`${visible.value}-${visible.movesAt}`}>
+    <div className="trophy-flash" key={`${flash.value}-${flash.movesAt}`}>
       <div className="trophy-flash-card">
         <div className="trophy-flash-label">New Trophy</div>
-        <div className="trophy-flash-value">Beast {visible.value}</div>
+        <div className="trophy-flash-value">Beast {flash.value}</div>
         <div className="trophy-flash-sub">defeated</div>
       </div>
     </div>

--- a/src/game/bot.ts
+++ b/src/game/bot.ts
@@ -316,7 +316,6 @@ export function runBot(seed: number, algo: SpawnAlgo, opts: RunOpts = {}): BotRe
     let chainLenSum = 0;
     let peakByMove50 = 0;
     terminationReason = "gameOver"; // overwritten below if loop exits other ways
-    // eslint-disable-next-line no-constant-condition
     while (true) {
       if (state.gameOver) { terminationReason = "gameOver"; break; }
       if (guard >= maxMoves) { terminationReason = "moveCapReached"; break; }


### PR DESCRIPTION
## Summary

Closes #4. Stacked on top of #6 — clears the remaining 12 lint errors (Bucket 3 + the LevelUpOverlay one I missed in the original triage) and the 3 warnings, so `npm run lint` exits clean.

After #6 merges, GitHub will auto-update this PR's base to `main`.

## Per-file changes

**`src/App.tsx`**
- `useState(Date.now())` → `useState(() => Date.now())`. Lazy initializer means the impure call only runs once on mount, satisfying `react-hooks/purity`.

**`src/components/FlyingTile.tsx`**
- Replace `Math.random()`-based `useRef` with `useId()` — stable, deterministic, no impure call during render. Animation name is now a plain `const` derived from `useId`, so the keyframes string and `animStyle` no longer access `.current` during render (clears 3 errors).
- Drop unused `styleRef` (set in effect, never read).

**`src/components/MergeBurst.tsx`**
- Replace the `particlesRef` "init-on-first-render" pattern with `useMemo`. The original code's comment already said *"Deterministic particle layout, computed once"* — `useMemo` is exactly what that means in React (clears 4 errors).
- Replace `Math.random()`-based `instanceId` with `useId()`.
- Drop the silenced `// eslint-disable-line react-hooks/exhaustive-deps` — effect deps now correctly list `id` and `particles`.

**`src/components/DevPanel.tsx`**
- Drop dead `export { readRuns };` re-export (verified: every caller — `App.tsx`, `useGameController.ts`, `runLog.ts` itself — imports `readRuns` directly from `../game/runLog`). Drop the now-unused `readRuns` from the file's import.
- File now exports only the `DevPanel` component, satisfying `react-refresh/only-export-components`.

**`src/components/TrophyFlash.tsx` and `src/components/LevelUpOverlay.tsx`**
- Same pattern in both: the effect was synchronously mirroring a prop to local state, then scheduling a `setState(null)` via `setTimeout` to auto-dismiss.
- Refactor: render the prop directly; track only a `hideAtMoves` / `hideAtLevel` marker that the effect sets *after* the timeout. Visibility becomes `prop.movesAt !== hideAtMoves` (derived). No synchronous `setState` inside the effect.
- Side benefit: clears the `react-hooks/exhaustive-deps` warning — deps array now correctly lists the whole prop.

**`src/game/bot.ts`**
- Drop unused `// eslint-disable-next-line no-constant-condition` above the run loop. The rule no longer fires on `while (true)` in the current eslint config, so the directive was inert.

## Test plan

- [x] `npm run lint` exits **0 errors, 0 warnings**.
- [x] `npm run build` clean.
- [ ] Smoke test: trophy flash and level-up overlay still appear and auto-dismiss after 1.5s. (I can't run a browser headless here — would appreciate a quick visual confirmation when you pull.)
- [ ] Smoke test: tile fly animation and merge burst particles still render correctly.

## Verification of derived-state refactor (TrophyFlash / LevelUpOverlay)

The behavioral semantics are preserved:

| Scenario | Old code | New code |
|---|---|---|
| `flash` is null | `visible` stays null → render null | `flash` is null → render null |
| New `flash` arrives | effect sets `visible = flash`, schedules clear at +1.5s | `flash.movesAt !== hideAtMoves` (stale) → render `flash`; effect schedules `setHideAtMoves(flash.movesAt)` at +1.5s |
| 1.5s later | effect callback `setVisible(null)` → render null | `flash.movesAt === hideAtMoves` → render null |
| New `flash` while old still showing | effect cleanup clears old timer; sets new `visible`, schedules new clear | effect cleanup clears old timer; new `flash.movesAt !== hideAtMoves` (still old) → render new flash; schedules new `setHideAtMoves` |

https://claude.ai/code/session_01F7c3HjABy4sJnotxWV1A19

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7c3HjABy4sJnotxWV1A19)_