### PR TITLE
Add docs + brainstorm swarm framework

### DIFF
--- a/docs/Game_Design_Concepts.md
+++ b/docs/Game_Design_Concepts.md
@@ -1,0 +1,528 @@
+# Game Design Concepts & Frameworks
+
+**Status:** Reference document — stable
+**Audience:** Designer (Evan), future projects, learners
+**Use case:** Vocabulary, frameworks, design principles for casual puzzle game design AND for design tooling
+**Updates:** Rare — only when new concepts are added or existing ones refined
+**Companion documents:**
+- *Merge Game Specification* — current state of the merge game project
+- *Merge Game Design Journal* — process log and audit notes for the game design
+- *Merge Game Tooling Specification* — current state of the design tooling project
+- *Merge Game Tooling Journal* — process log and audit notes for the tooling design
+
+---
+
+## How to use this document
+
+This is a textbook-style reference. It's organized in two parts:
+
+- **Part A — Game Design Concepts (Sections 1-16).** Vocabulary, frameworks, and design principles for casual puzzle games — specifically those with progression mechanics, chain mechanics, and merge mechanics.
+- **Part B — Internal Tooling Concepts (Sections 17-25).** Design principles for the internal tools that support game design work — tuning consoles, simulation harnesses, design intent solvers, and related infrastructure.
+
+You can:
+- Read either part top to bottom for an overview of the field
+- Skip to a specific concept (numbered sections) when you need to recall a definition
+- Use this as a starting point for future game design projects
+
+Most of the content here was assembled in service of a specific project (the merge game and its tooling), but the concepts themselves are general-purpose.
+
+---
+
+# PART A — GAME DESIGN CONCEPTS
+
+## 1. The three fields
+
+We started by distinguishing three fields that share vocabulary but are genuinely distinct:
+
+- **Game design** — the craft of designing playable systems (mechanics, dynamics, aesthetics, playtesting). Mostly a humanities/craft discipline.
+- **Game theory** — the mathematics of strategic decision-making among rational agents (Nash equilibria, zero-sum, cooperative games). Mostly economics/math.
+- **Gamification** — applying game-like elements (points, progression, feedback loops) to non-game contexts. Mostly product/behavioral design, often controversial.
+
+We focused on game design because the goal is to build something. Game theory and gamification have informed parts of the conversation (mechanism design surfaced as a candidate interest area early on; gamification's "dark patterns" framed the engagement-vs-affection distinction later).
+
+## 2. The MDA framework
+
+The most-cited academic framework in game design (Hunicke, LeBlanc, Zubek, 2004):
+
+- **Mechanics** — the formal rules and components of the game (what the system literally does)
+- **Dynamics** — the behavior that emerges when those rules meet a player (what actually happens during play)
+- **Aesthetics** — the emotional responses the player has (fun, tension, pride, surprise)
+
+Key insight: **the designer builds from M up** (rules → emergent behavior → emotion), but **the player experiences A down** (feels emotion → notices behavior → eventually understands rules). Misalignment between these perspectives is the root of most design failure.
+
+## 3. The six-layer working frame
+
+A practical decomposition of how casual puzzle games stack:
+
+| Layer | What it is | Vocabulary lives here |
+|---|---|---|
+| 1. Core mechanic | The fundamental rule of play | Verbs, state, rules, the core loop |
+| 2. Content design | Special tiles, blockers, wilds, modifiers | Friction, boons, level layouts |
+| 3. Objectives | What defines winning a level/round | Score targets, move limits, survival |
+| 4. Meta-progression & economy | What persists between rounds | Currency, stars, boosters, energy, daily challenges |
+| 5. Game feel / juice | Polish layer | Particles, screen-shake, hit confirms |
+| 6. Cross-cutting concepts | Principles governing all above | Risk/reward, flow, mastery curves |
+
+This frame structures our design process: we work bottom-up (Layer 1 first), and each layer has its own design vocabulary.
+
+## 4. Engagement vs Affection vs Mastery
+
+Three distinct retention concepts often conflated, especially in mobile gaming:
+
+- **Engagement** — people keep playing right now. Easy to manufacture with variable rewards, energy timers, FOMO, streaks. Effective short-term, corrosive long-term. Most "F2P retention design" is this.
+- **Affection** — people recommend the game, return after long absences, feel *good* about time spent. Requires actual depth, respect for player time, honest reward structure.
+- **Mastery satisfaction** — players notice themselves *getting better*. The deepest hook of all and the most underrated.
+
+The games people genuinely return to for years (Tetris, Threes!, Drop7, Wordle, NYT Crossword, Slay the Spire) hit affection and mastery without leaning on engagement tricks. **Engagement follows from love; love does not follow from engagement.**
+
+This distinction set our optimization target: design for affection and mastery, not engagement.
+
+## 5. The six pillars of beloved games
+
+The shared properties of games people genuinely love and return to:
+
+1. **Depth that reveals slowly.** Simple rules, vast strategic space that keeps unfolding over hours and hundreds of hours of play.
+2. **Interesting decisions every move.** Sid Meier's bar — every action involves a real tradeoff with no obviously-correct answer.
+3. **Failure that teaches.** When you lose, you understand why and want to try again. The death state illuminates the strategy.
+4. **Felt mastery curve.** Players notice themselves getting better. Yesterday's hard puzzle is today's easy one. *The most underrated retention mechanic.*
+5. **Aesthetic identity.** A distinctive look, sound, and feel that's recognizable in two seconds. (Threes! has more identity than 2048; same mechanic, totally different soul.)
+6. **Honest reward structure.** What you put in, you get out. Skill-correlated rewards, not slot-machine rewards. Luck doesn't dominate decisions.
+
+These pillars become the audit criteria for kernel design (Step 1.5).
+
+## 6. Game archetypes
+
+Distinct flavors of "loved and returned to" with different design priorities:
+
+| Archetype | Example | Key design priorities |
+|---|---|---|
+| **Cult favorite** | Threes! | Depth, signature aesthetic, infinite replayability. Skip heavy meta-progression. |
+| **Mass casual** | Candy Crush | Hundreds of designed levels, currency, energy, social hooks. Heavy meta-progression. |
+| **Daily ritual** | Wordle, NYT Crossword | One fresh puzzle/day. Share-friendly results. No infinite play. |
+| **Hardcore mastery** | Slay the Spire | Extreme depth. Runs feel meaningfully different. Long-tail engagement. |
+| **Cozy / chill** | Stardew, Suika | Warmth, forgiveness, vibe. Low pressure. |
+
+These have radically different design requirements — choosing an archetype shapes meta-progression, content load, monetization, art direction, even pacing.
+
+## 7. Kernel and knobs (modal design)
+
+A pattern used by games that serve multiple archetypes simultaneously: **separate what's invariant (kernel) from what varies between modes (knobs).**
+
+Examples:
+- Tetris: marathon, sprint, ultra, battle modes — all share the same kernel (place falling shape; full lines clear) with different knobs (speed curve, win condition, opponent presence).
+- Slay the Spire: standard runs + ascension + daily climb + custom seeds — all share the deck-building roguelike kernel with different difficulty/seeding knobs.
+- Hades: base game + Pact of Punishment modifiers — shared kernel with stackable challenge knobs.
+
+The principle: **the kernel must be the minimum shared experience across all modes.** If a rule isn't true in *every* mode, it's a knob, not a kernel.
+
+The **hero mode** is the one mode you design first, polish first, and use to validate the kernel. Get this wrong and you waste months building modes for a mechanic that wasn't fun.
+
+## 8. Classes of tradeoffs in puzzle games
+
+A "tradeoff" = a choice where picking option A means giving up a real benefit of option B. The Sid Meier insight is that good puzzle games **layer multiple tradeoffs into a single move.**
+
+Eight named classes that recur across the genre:
+
+| Tradeoff | Pits this against this |
+|---|---|
+| **Now vs Later** | Immediate payoff vs better future state |
+| **Big vs Small** | High-cost/high-reward vs low-cost/low-reward |
+| **Use vs Save** | Spend a powerful resource or hold it |
+| **Path vs Placement** | Which tiles you touch vs where the result ends up |
+| **Climb vs Clear** | Advance tier vs free space *(specific to merge games)* |
+| **Simple vs Risky** | Guaranteed small vs probable larger |
+| **Local vs Global** | Solve immediate corner vs reshape whole board |
+| **Greedy vs Strategic** | Obvious good move vs hold for emerging pattern |
+
+A *real* tradeoff has genuine value on both sides. A *fake* tradeoff has one obviously-correct side, producing no real choice — that's a dead decision and a dead mechanic.
+
+## 8a. Spawn distribution: three concepts that aren't the same
+
+Late in the design discussion we surfaced an important distinction. Three concepts that get conflated but are actually independent levers:
+
+1. **Range** — the set of tile values the system supports. Currently 2-256 (eight tiers). Could be extended.
+2. **Active tiers on the board** — how many distinct values can exist on the board at once. Constrained by range plus what chains have created.
+3. **Spawn algorithm** — which subset of values actually spawns each turn, and with what weights. Independent of range.
+
+Each is a separate design decision:
+- Range determines the *ceiling* of what's possible
+- Active tiers determines the *variety* of what's present
+- Spawn algorithm determines the *distribution* of what appears
+
+For our v1: range = 2-256, active tiers = 8 (same as range, no restriction), spawn algorithm = power-law decay with weights = 1/value. These are tunable independently.
+
+The retirement mechanic interacts with all three: it shifts the spawn algorithm (lowest tier stops spawning) which, via sliding window, shifts the range (new top tier joins). Active tiers stays constant.
+
+## 9. Layer 1 deep-dive: core mechanics
+
+A mechanic is a formal rule of the game with three components:
+
+- **Verbs** — what the player can do (move, merge, place, swap, draw, build...)
+- **State** — what exists and changes (tiles on a board, cards in hand, units on a map...)
+- **Rules** — how verbs operate on state (identical tiles merge into double value...)
+
+### Three named lenses on mechanics
+
+1. **Sid Meier's definition:** "A game is a series of interesting decisions." Every mechanic should produce one. If a player's choice has no real consequence or has an obvious dominant answer, the mechanic is broken.
+2. **Doug Church's "intention and perceivable consequence."** A good mechanic lets the player form an intention and *immediately perceive* the result. Invisible delayed effects break this.
+3. **Daniel Cook's "skill atoms."** Every mechanic is a tiny cycle: action → simulation → feedback → modeling → mastery. Well-designed mechanics produce a learning curve on their own.
+
+### Five principles of good mechanic design
+
+1. **Elegance** — small rule, vast emergent depth (Go, Tetris)
+2. **Coherence** — mechanics that share a theme reinforce each other
+3. **Interesting-decision test** — every choice has meaningful tradeoffs
+4. **Emergent over scripted** — great mechanics produce experiences the designer didn't anticipate
+5. **Avoid dominant strategies / degenerate mechanics** — no single tactic always wins; no unintended loophole breaks the design
+
+### Categories of mechanics (broad taxonomy)
+
+- Movement, resource management, pattern-matching, combat/interaction, construction/placement, information mechanics, probability/generation, time mechanics, economic mechanics
+
+Counting the *number of distinct verbs* in a game is a quick proxy for its complexity.
+
+### Two case studies referenced
+
+- **Tetris** (Pajitnov, 1984). One verb, one state, one rule. Difficulty from speed alone. Most-ported game in history. *A single great mechanic can carry a game forever.*
+- **Threes!** (2014). Slide one tile + one merge rule + one preview tile. The preview is the key design choice — partial future information makes decisions interesting in a way 2048's pure randomness doesn't. *Small rule additions can profoundly change strategic depth.*
+
+## 10. Layer 2 deep-dive: content design
+
+The "stuff that fills the board" — special tiles and modifiers. Splits into friction and boons.
+
+### Friction elements
+
+- **Blockers / obstacles** — static tiles taking up space, can't be chained, must be cleared somehow
+- **Hazards** — actively threatening (timers that fill cells with garbage)
+- **Locked tiles** — frozen, need N adjacent merges to unlock
+- **Decay tiles / timer tiles** — change state over moves (the "must be chained within X moves or it becomes a blocker" pattern)
+- **Spreading hazards** — propagate to neighbors each turn (Candy Crush ice)
+- **Garbage / junk** — periodically spawned non-chainable clutter
+
+### Boon elements
+
+- **Wilds / jokers** — match any value
+- **Multipliers** — boost chain output
+- **Bombs / clears** — single-use tiles wiping a row, column, or value-X tiles
+- **Specials / power-ups** — earned tiles with abilities (swap, undo, peek)
+- **Modifier zones** — board regions with different rules
+
+### Special-tile creation rules
+
+The genius of Candy Crush: **specific match patterns produce specific specials.** Match 4 in a line → striped candy. Match 5 → color bomb. Match L-shape → wrapped candy. The pattern "do something fancy → get something fancy" is a *reward gradient* that teaches players to want harder matches.
+
+For our merge game: chain length 5+ could spawn a wild. Chains using 3+ doubling extensions could spawn multipliers. Chains ending on a specific tier could spawn bombs. *(Deferred to Layer 2 design phase.)*
+
+## 11. Layer 3 deep-dive: objectives
+
+The "win condition" vocabulary. Most casual games combine 2-3 per level.
+
+Standard catalog:
+
+- **Score target** — reach N points
+- **Tile target** — produce a tile of value X
+- **Move limit** — within Y moves
+- **Time limit** — within Y seconds
+- **Survival** — last as long as possible
+- **Combo objective** — perform a chain of length N
+- **Clear objective** — clear all tiles of type X
+- **Collect objective** — produce N tiles of value X
+- **Bring-down** — items at top must "fall" through merges to bottom
+
+Levels are typically *assembled* from these — most levels combine 2-3 stacked objectives.
+
+## 12. Layer 4 deep-dive: meta-progression and economy
+
+The reasons to come back. Critical to longevity, easy to do badly:
+
+- **Levels / chapters** — designed sequence of levels
+- **Stars / medals** — 1/2/3 star ratings per level
+- **XP and player level** — overall progress meter
+- **Currency** — earned in rounds, spent on:
+  - **Boosters** — pre-game advantages
+  - **In-game power-ups** — used during play
+  - **Lives / energy** — limit play sessions
+- **Daily challenges** — fresh content each 24h
+- **Battle pass / season pass** — time-limited progression track
+- **Achievements** — long-term goals
+- **Leaderboards** — social comparison
+- **Unlockables** — themes, modes, characters
+
+Vocabulary: **core loop** (one round of play) vs **meta loop** (between rounds). Both must feel rewarding in their own right.
+
+## 13. Layer 5 deep-dive: game feel / juice
+
+The polish layer that solo developers consistently underweight. Named concepts:
+
+- **Juice** (Jonasson/Purho) — visual/audio feedback that makes actions feel kinetic
+- **Hit confirm** — clear feedback that an action registered
+- **Reward burst** — celebration of success scaled to magnitude
+- **Anticipation** — telegraphing what's about to happen
+- **Wind-down / settle** — visual rest after action
+
+Reference: "Juice It Or Lose It" GDC talk by Martin Jonasson and Petri Purho.
+
+## 14. Layer 6 deep-dive: cross-cutting concepts
+
+Principles governing multiple layers at once:
+
+- **Risk/reward decision** — every meaningful choice should have one
+- **Push-your-luck** — keep going for more reward at increasing risk
+- **Agency vs randomness** — balance between skill and luck
+- **Mastery curve** — how skill ceilings reveal themselves over hours
+- **Flow** (Csíkszentmihályi) — optimal challenge zone
+- **Difficulty curve** — how challenge scales over levels
+- **Variable reward schedules** — Skinner-derived; payoffs at unpredictable intervals
+- **Roguelike elements** — runs end, permadeath, but meta-currency persists
+- **Onboarding / tutorialization** — teaching rules without text walls
+
+## 15. Genre survey: number-merge games
+
+The canonical lineage and what each does differently:
+
+| Game | Year | Movement | Merge rule | Number progression | Goal |
+|---|---|---|---|---|---|
+| **Triple Town** | 2010 | Discrete placement | 3 same → 1 next | Themed upgrade chain | Reach high tier |
+| **Drop7** | 2009 | Drop into columns | Pattern (value N clears in row/col of N) | 1-7 discs | Survive scoring |
+| **Threes!** | 2014 | Slide one tile | 1+2=3 then doubling | Custom: 1,2,3,6,12,24... | Reach high tile |
+| **2048** | 2014 | Slide all the way | 2 same → 1 next | Powers of 2 | Reach 2048 |
+| **Suika** | 2021 | Drop with physics | 2 same → 1 next | Themed upgrade chain | Reach watermelon |
+
+Design dimensions used to compare them:
+
+- **Movement model** — slide all / slide one / drop with physics / discrete placement
+- **Merge rule** — 2 same / 3 same / pattern-based
+- **Number progression** — powers of 2 / Fibonacci / arbitrary upgrade chain / themed
+- **Goal structure** — reach target / survive / score / objective-based
+- **Signature twist** — every successful entry has one thing predecessors don't
+
+Our game's hybrid combines elements: chain-based (path-traversal like Boggle), powers of 2 (like 2048), 8-way adjacency, *two extension rules* (same-value OR doubled-adjacent), gravity drops + spawn (like Drop7), 6×7 portrait grid.
+
+## 16. Recommended references
+
+Captured for future deep-dives:
+
+- **Hunicke, LeBlanc, Zubek**, "MDA: A Formal Approach to Game Design and Game Research" (2004) — the canonical framework
+- **Jesse Schell**, *The Art of Game Design: A Book of Lenses* — 100 lenses, the practical bible
+- **Dixit & Nalebuff**, *The Art of Strategy* — readable game theory
+- **Daniel Cook**, blog "Lostgarden" — especially "Game Skill Atoms" and "Loops and Arcs"
+- **Frank Lantz**, writings on Drop7 — the closest cousin to our game
+- **Jonasson & Purho**, "Juice It Or Lose It" GDC talk
+- **Roger Caillois**, *Man, Play and Games* — taxonomy of play (agon, alea, mimicry, ilinx)
+- **Bernard Suits**, *The Grasshopper* — what is a game philosophically
+- **Anna Anthropy**, *Rise of the Videogame Zinesters* — manifesto for personal games
+
+---
+
+# PART B — INTERNAL TOOLING CONCEPTS
+
+The sections above (1-16) cover game design proper. The sections below (17-25) cover the design of *internal tooling* used to build games. Most of these concepts are general-purpose for any internal tooling; a few are specific to game design tools.
+
+The sections share vocabulary with the game design sections — kernel/knobs, audit principles, archetype thinking — but apply them to tools as the artifact being designed.
+
+## 17. The role of internal tools in game design
+
+Tools are the **substrate that makes design iteration cheap.** Game design is a search problem — you don't know what fun is until you find it, and you find it by trying many variants. The cost of one iteration sets the upper bound on how thoroughly you can search the design space. Tools lower iteration cost.
+
+Three named principles from the field:
+
+**1. Tools are designed, not built.** Treating tools as throwaway scaffolding produces brittle, untrusted tools that nobody uses. Designed tools — with intentional UX, clear workflows, and audited assumptions — get used. The discipline is to apply the same design rigor to the tool that you'd apply to the product. *Carmack repeatedly said the game is downstream of tool quality.*
+
+**2. The cost of tool quality compounds.** Every design decision after a tool is built benefits from that tool. A tool that's 10% better than a worse tool, used 100 times, isn't 10% more valuable — it's compounding. The corollary: undertooling early is *expensive*, but it's invisible because the cost shows up as slow iteration rather than a line item.
+
+**3. Tools encode hypotheses.** A parameter slider implies "this matters and is worth varying." A telemetry chart implies "this metric is meaningful." Tools aren't neutral — they shape what the team thinks about. Bad tools narrow attention to the wrong variables.
+
+## 18. Tool archetypes
+
+Just as games have archetypes, tools have them — and the right archetype for a tool depends on its primary user and use case:
+
+| Archetype | Primary user | Optimization target | Failure mode |
+|---|---|---|---|
+| **Designer's microscope** | Solo designer / small team | Speed of "what if?" answers | Becomes a procrastination toy |
+| **Team's dashboard** | Cross-functional team | Shared awareness, agreement | Becomes meeting-driven, slow |
+| **QA's stress rig** | Quality engineers | Bug reproduction, edge cases | Diverges from production |
+| **Researcher's instrument** | Designer-as-scientist | Reproducibility, statistics | Optimizes for wrong metric |
+| **Public playground** | External audience | Engagement, education | Wrong-audience design choices |
+
+The tool's archetype shapes everything downstream — UI complexity, exposed parameters, workflow assumptions, security model. Other archetypes are deferred but should not be foreclosed by architecture.
+
+## 19. Single source of truth (the load-bearing tooling principle)
+
+The single biggest mistake in game tooling: **the simulator and the game disagree.** A sim harness or analytics tool that has its own copy of "what is a chain" or "how does retirement work" will, over time, drift from the actual game. This is **simulation drift**, and it's catastrophic when discovered — every analytical conclusion the team reached using the simulator becomes suspect.
+
+The fix is architectural:
+
+> **Extract pure game logic into a module that has no UI dependencies. The playable game imports it. The simulator imports it. Both are downstream consumers of the same logic.**
+
+This pattern shows up in many fields:
+- Web development: separate "domain logic" from "view layer"
+- Database systems: separate "schema" from "presentation"
+- Machine learning: separate "model" from "training/serving infrastructure"
+- Compilers: separate "frontend parsing" from "backend codegen"
+
+In game terms, the model is:
+
+```
+[ pure game logic module ]   ← the single source of truth
+        ↑               ↑
+        │               │
+   [ playable game ]  [ sim harness ]
+        ↑                   ↑
+        │                   │
+   [ tuning console ]  [ batch runner ]
+```
+
+The pure-logic module knows *nothing* about rendering, sound, sliders, or charts. It exposes a deterministic API: given a state and an action, produce the next state.
+
+This isn't optional for tooling work. Without it, every tool you build accumulates technical debt that eventually invalidates it.
+
+## 20. Instrumentation principles
+
+Once the pure-logic module exists, **instrumentation** is what makes it observable. Every meaningful event in the game emits a signal. Three principles:
+
+**1. Instrument the model, not the view.** Events fire from the game-logic module, not from UI code. This way, both playable games and simulated games emit the same events.
+
+**2. Events should be self-describing.** Each event includes context (current state, parameters in effect, timestamp/turn number) so that a single event log can be meaningfully replayed or analyzed. *"Chain completed"* is not enough; *"chain completed: length 5, doublings 2, same-values 1, result tile 32, position (3,4), turn 47, k=2, grid 6×7"* is.
+
+**3. Default to recording everything; filter at analysis time.** Storage is cheap; recreating sessions is expensive. Record liberally during prototype phase. Tighten in production.
+
+## 21. Parameter exposition (what to expose, what to fix)
+
+The temptation: expose every parameter. The reality: **most parameters shouldn't be exposed**, because exposing them implies "this is worth varying," which is often wrong.
+
+The named tradeoff: **exposition vs decisiveness.**
+
+- *Over-exposition* — a sea of sliders. Encourages tuning by feel rather than by playtest. Defers commitment indefinitely.
+- *Under-exposition* — too few sliders. Forces code changes for design questions, which are slow and intimidating.
+
+The discipline:
+
+**Three exposition tiers:**
+
+| Tier | Description | Example |
+|---|---|---|
+| **Tier 1 — Live tunables** | Exposed in the UI, changeable during play | Spawn weights, key formula constants |
+| **Tier 2 — Config tunables** | In a config file/object, changeable but requires restart | Grid dimensions, structural parameters |
+| **Tier 3 — Code constants** | Hard-coded; changing requires code editing | Fundamental design commitments |
+
+The principle: **tier corresponds to certainty.** Tier 3 things are settled by design and shouldn't be testable. Tier 2 things are settled but might want comparison. Tier 1 things are actively under exploration.
+
+If everything is Tier 1, nothing is decided. If nothing is Tier 1, the tool isn't doing its job.
+
+## 22. Simulation harness patterns
+
+A sim harness is a non-visual game runner driven by automated strategies. Three named pieces:
+
+**1. Strategies (the "player").** A strategy is a function that, given a game state, returns an action. Three baseline strategies are usually enough to triangulate:
+
+- **Random valid play.** Picks any legal action at random. Establishes the worst-case difficulty floor.
+- **Greedy (highest-immediate).** Always picks the action with the best immediate result. Establishes the obvious-strategy ceiling and reveals dominant strategies.
+- **Heuristic (designed approximation of skilled play).** Encodes design intent: prefer X in early game, prefer Y when board is full, etc. Best proxy for skilled human behavior.
+
+A bot is *not* a substitute for a human, but multiple bots covering the strategy space approximate the *envelope* of human outcomes.
+
+**2. Runners (the "experiment").** A runner takes a strategy and a configuration, runs N games, collects results. Two flavors:
+
+- **Single-config runner** — given one parameter set, run 1000 games, output statistics.
+- **Sweep runner** — vary one parameter across a range, run 1000 games at each setting, output a chart.
+
+**3. Analyzers (the "interpreter").** A runner produces raw event logs. An analyzer extracts statistics — distributions, percentiles, correlations.
+
+The key principle: **strategies, runners, and analyzers are independent layers.** You can swap any one without rewriting the others.
+
+## 23. Failure modes specific to tooling
+
+Worth naming because they're predictable:
+
+**1. The procrastination trap.** Building tools to avoid playing the game and finding out it isn't fun. Combat: every tool feature has to answer a specific real question; if you can't name the question, don't build it.
+
+**2. Simulation drift.** Sim and game disagree. Combat: single source of truth (Section 19).
+
+**3. Sliderification.** Every decision becomes a slider. Combat: tier discipline (Section 21).
+
+**4. Statistics theater.** Producing impressive charts that don't change any decisions. Combat: every metric should pre-commit to a decision rule. "If median game length under config X is below 15 minutes, we change spawn rate" — *not* "let's see what happens."
+
+**5. Bot overfitting.** Tuning the game to make bots happy. The bot is a lens, not the player. Combat: keep human playtest in the loop alongside simulation.
+
+**6. The maintenance tax.** Tools that aren't maintained drift, break, and stop being trusted. Combat: build less; treat tool code with the same review/test discipline as game code.
+
+## 24. The "build less, build well" discipline
+
+Three heuristics worth adopting:
+
+**1. Smallest tool that answers the question.** Resist the urge to build "the right architecture" up front. Start with the cheapest thing that produces an answer; add structure as the tool's value justifies it.
+
+**2. One question per build cycle.** Each tool feature exists to answer a specific question. When the question is answered, the feature is done. Avoid the open-ended "this might be useful someday" build.
+
+**3. Docs > UX.** A tool that's well-documented but mediocre to use is more valuable than a beautiful tool nobody understands. Comments, README, decision records — the tool's *understandability* compounds over time.
+
+## 25. Forward and inverse modes in design tooling
+
+Design tools fall into two modes that look related but solve different problems and require different architectures:
+
+**Forward mode: parameters → outcomes.** "Given this configuration, what kind of game results?" The designer sets inputs; the tool reveals outputs. This is the natural mode of tuning consoles and simulation harnesses. Cognitive load: experiment-driven exploration.
+
+**Inverse mode: outcomes → parameters.** "Given this design intent, what configurations achieve it?" The designer states targets; the tool reveals which inputs produce them. Cognitive load: requirements-driven solving.
+
+The split has names across many fields — **forward problem vs inverse problem** in optimization, **tuning vs design intent solving** in game design, **analysis vs synthesis** in mechanism design, **prediction vs inference** in ML.
+
+### Why inverse mode is fundamentally harder
+
+Four reasons inverse mode is mathematically harder than forward mode:
+
+**1. The parameter space is large.** With many tunable parameters, the full configuration grid quickly grows beyond exhaustive enumeration.
+
+**2. The mapping is non-injective.** Multiple parameter sets can produce similar metrics — meaning "what configuration produces this game" doesn't have a unique answer. Inverse mode returns a *set* of answers, not one.
+
+**3. The mapping is non-monotonic.** Increasing one parameter doesn't reliably move a given metric in one direction. You can't just "tune one slider until the metric matches."
+
+**4. Design intent is multi-dimensional.** Stating intent isn't one number — it's a *vector* of metrics (length, max value reached, event frequency, distribution shape, failure rate). Optimizing for one may trade against another.
+
+These are not blockers. They're solved problems in optimization theory. They just require more sophisticated tooling than forward mode.
+
+### Three approaches to inverse mode
+
+**Approach 1: Parameter sweep + structured filtering.** Brute-force forward simulation across a grid of configurations, store all results in a database, then filter by target outcomes. The "inverse" is structured search through a forward-generated dataset.
+
+- *Pros:* Conceptually simple. Reuses forward simulator. Results are real (no model assumptions). Easy to extend with new metrics.
+- *Cons:* Sweep is expensive — only feasible when individual simulations are fast. Coverage is limited to discretized configurations.
+- *When right:* Small-to-medium parameter spaces, fast simulators, when you want ground truth answers.
+
+**Approach 2: Surrogate models / Bayesian optimization.** Build a statistical model that learns the parameter→metric mapping from a smaller sample of forward runs, then optimize over the model rather than the simulator directly.
+
+- *Pros:* Far more efficient than brute force. Standard ML/research technique.
+- *Cons:* Requires more sophistication. Surrogate model can be wrong. Adds implementation and validation complexity.
+- *When right:* Large parameter spaces, slow simulators, when you have time to invest in modeling infrastructure.
+
+**Approach 3: Direct gradient-free optimization.** Use algorithms like CMA-ES, evolutionary strategies, or simulated annealing to optimize the simulator directly as a black-box function.
+
+- *Pros:* Powerful. Handles complex objective functions including multi-objective tradeoffs.
+- *Cons:* Most complex to set up and validate. Easy to misconfigure (local minima, premature convergence). Often overkill for prototyping scope.
+- *When right:* Production-scale tuning at large studios. Late-stage live-game balancing.
+
+### The unifying insight: same data, two queries
+
+Forward and inverse aren't really separate tools — they're the **same dataset queried in different directions.** A simulation database with rows like:
+
+```
+{ inputs: { k: 2, grid: 6×7, ... }, outputs: { length: 15.3, max_tile: 1024, ... } }
+```
+
+Forward query: "for these inputs, what were the outputs?"
+Inverse query: "filter rows where outputs match my targets, return inputs."
+
+This unification has architectural implications: **build the simulation harness's data model with inverse querying in mind from day one.** Doing so means inverse mode comes nearly free once forward batch mode exists. Treating them as separate tools doubles the work.
+
+### Practical guidance
+
+Three rules of thumb:
+
+1. **Build forward modes first.** Inverse mode requires forward mode under the hood. Until you've validated the simulator (forward, single-config), inverse mode is building on sand.
+
+2. **Use Approach 1 unless proven inadequate.** Brute-force sweep + structured filtering covers 80% of design intent questions and is genuinely cheap to extend. Reach for surrogates or optimization only when sweep becomes too slow or the parameter space too large.
+
+3. **Multi-objective is normal; design for it.** Real design intent involves multiple metrics simultaneously. The intent solver should support multi-criteria filtering and Pareto-front views, not just single-metric optimization.
+
+---
+
+*End of Concepts document.*

--- a/docs/Merge_Game_Design_Journal.md
+++ b/docs/Merge_Game_Design_Journal.md
@@ -1,0 +1,575 @@
+# Merge Game Design Journal
+
+**Status:** Living document — process record
+**Audience:** Designer (Evan), future-self auditing decisions
+**Use case:** "Why did we choose X?" / "What did we consider and reject?" / "What should I revisit?"
+**Updates:** Each time a design decision is discussed (settled or rejected)
+**Last updated:** Phase 1 complete (Steps 1.1-1.5); ready for Phase 2
+
+**Companion documents:**
+- *Game Design Concepts & Frameworks* — vocabulary referenced throughout
+- *Merge Game Specification* — current settled state of the design
+
+---
+
+## How to use this document
+
+This is the **process record** — the meeting minutes of design conversations. It contains:
+
+- **Phase-by-phase narrative** of decisions made, including alternatives considered
+- **The kernel audit** against the six pillars of beloved games
+- **Soft commitments** with revisit triggers
+- **Things rejected** and why
+- **Things deferred** with notes on when to revisit
+- **Things to verify in playtest**
+
+When auditing a past decision: find the relevant Phase/Step in the narrative, see the alternatives we considered and the rationale, then decide whether new information changes the answer. If you change a decision, update the *Specification* and add a note here explaining what changed and why.
+
+The Specification is the contract; this Journal is the metadata about why the contract reads the way it does.
+
+---
+
+## Process framing
+
+Our approach has been **iterative narrowing under explicit assumptions.** At each step:
+1. Identify the open decision
+2. State happy-path assumptions / defaults
+3. Surface candidate options
+4. Apply criteria + analysis
+5. Pick (or defer with explicit reasoning)
+6. Note what we'd revisit and under what conditions
+
+We've kept commitments **soft** — ideas as working assumptions we proceed under, flag as revisitable, and revisit when new info arrives. This is a design philosophy, not just convenience: hard commitment too early locks out better ideas; refusal to commit at all prevents progress. Hold loosely, advance anyway.
+
+## Phase 0 — Genre identification and concept definition
+
+### How we got here
+
+Started broad: "I want to learn about game design, theory, gamification." Narrowed through several rounds:
+
+1. Identified three distinct fields; user wanted understanding of all three
+2. User had specifically been thinking about a 2D number-merging game
+3. Toured the canonical lineage of merge games (Threes!, 2048, Triple Town, Suika, Drop7)
+4. User described his hybrid mechanic
+5. Mechanic reflected back, novelty identified
+
+### Concept summary (what user described)
+
+> "The board is structured with columns and rows. Tiles are numbers. You start with 2,4,8,16,32,64,128,256. You merge numbers together by chaining them. You must start a chain off with 2 consecutive of the same number. And then you can either select the same number or to an adjacent tile (all directions including diagonal) where that number is doubled. Then when your chain is done, a resulting number is calculated and that becomes the last tile. Then tiles move down and new ones spawn. Your goal is to reach particular max tile levels without dying - when there are no moves left."
+
+### What's novel about this concept
+
+1. **Two-rule chain extension** (same OR doubled-adjacent) is a unique decision space combining match-3 (same-value) with 2048 (doubling) within path-traversal (chain).
+2. **Wide starting spawn pool** (2-256) — most merge games start with everything as 2 or 4 and build up. Wide pool means players begin with messy boards and find elegant chains.
+3. **Gravity + spawn cascading** after a chain creates Drop7-like opportunities for accidental follow-up chains.
+
+The closest cousins are Threes!/2048, Two Dots, Drop7 — but no single existing polished game combines chain-by-adjacency + two extension rules + single-result-tile + column gravity. Real signature potential.
+
+## Phase 1 — Pin down enough to prototype
+
+### Step 1.1 — Archetype selection
+
+**Decision:** Multi-mode game with kernel + knobs. **Endless** is the hero mode.
+
+**User input:** Wanted a mix of cult favorite, mass casual, hardcore mastery, and cozy/chill. Explicitly excluded daily ritual.
+
+**Resolution path:**
+
+1. Recognized that user's mix is a *named pattern* — modal design. Examples: Tetris (marathon/sprint/ultra/battle), Slay the Spire (standard/ascension/daily/seeded), Hades (base + Pact of Punishment), Civilization (scenarios/difficulties/maps).
+2. Introduced kernel-and-knobs framework: separate invariant (kernel) from variable (knobs) to support multiple modes elegantly.
+3. Proposed mode-by-mode mapping:
+
+| Mode | Archetype | Knob settings |
+|---|---|---|
+| **Endless** | Cult favorite | Default knobs, no time/move limit, death on, goal = max tile / score |
+| **Levels** | Mass casual | Designed boards, objective stacks, move limits, star ratings, currency |
+| **Ascension** | Hardcore mastery | Modifier-based runs (Slay the Spire model), daily seeded challenges |
+| **Drift** | Cozy | Death off, slow spawns, soft visuals/audio, no score pressure |
+
+4. Recommended Endless as hero mode because: (a) purest kernel expression, (b) cheapest to prototype, (c) all other modes are modifications of it.
+
+**Counterpoint considered (and rejected):** Some designers argue you should prototype the *most-constrained* mode first (a single Levels-mode level) because constraints reveal mechanic weaknesses faster. We rejected this for our game — the mechanic needs to prove it sustains 30+ minutes of pure play before we know if it deserves levels at all.
+
+**Rationale:** Endless validates the kernel; everything else is downstream.
+
+**Status:** Soft commitment. Revisit if Endless prototype reveals fundamental mechanic problems that constraints (Levels-style) would have surfaced earlier.
+
+### Step 1.2 — Result rule
+
+The single most consequential open decision. Determines what kind of game this becomes.
+
+#### Step 1.2a — Criteria for "good"
+
+A result rule should ideally satisfy:
+
+1. **Produces interesting decisions every move** — chain options have real tradeoffs (Sid Meier's bar)
+2. **Stays in powers-of-2 system** — outputs are 2, 4, 8, 16, ... — no weird in-betweens
+3. **Both extension types feel valuable** — same-value and doubled-adjacent each have strategic use
+4. **Length rewarded proportionally, not exponentially** — long chains pay better but not so dramatically that "find longest" dominates
+5. **Predictable in advance** — player can compute result while planning
+6. **No dominant strategy** — no single chain pattern always wins
+7. **Simple to state** — fits in a tweet ideally
+
+Load-bearing criteria: #1 (interesting decisions), #2 (number system), #6 (no dominant strategy).
+
+#### Step 1.2b — Tradeoffs analysis
+
+Discussed the eight classes of tradeoffs in puzzle games and applied each to the merge game. Found that the chain mechanic produces a *particularly rich* tradeoff space — six or seven of the eight classes are alive in every move. *Climb vs Clear* is the central tradeoff (doubling extensions advance tier, same-value extensions free space). This was a strong sign of real depth in the kernel.
+
+#### Step 1.2c — Stress-testing candidate rules
+
+Defined nine test chains spanning meaningful cases:
+
+| Label | Chain | Length | Doublings (d) | Same-value extensions (s) |
+|---|---|---|---|---|
+| T1 | 2,2 | 2 | 0 | 0 |
+| T2 | 2,2,2,2 | 4 | 0 | 2 |
+| T3 | 2,2,4,8 | 4 | 2 | 0 |
+| T4 | 2,2,4,4,8 | 5 | 2 | 1 |
+| T5 | 2,2,2,2,2,2,4,4,8 | 9 | 2 | 5 |
+| T6 | 4,4,8,8,16,16,32 | 7 | 3 | 2 |
+| T7 | 64,64,128 | 3 | 1 | 0 |
+| T8a | 2,2,4 | 3 | 1 | 0 |
+| T8b | 2,2,4,4 | 4 | 1 | 1 |
+
+Initially considered 4 candidate rules, then proved Rule 2 = Rule 3 algebraically (under our chain mechanic, "every step doubles" and "doublings climb tiers, same-values multiply on top" are mathematically identical). Reduced to 3 meaningful rules:
+
+- **Rule A** — last × 2
+- **Rule B** — start × 2^(length−1)
+- **Rule C** — tile follows Rule A; chain length earns separate score
+
+| Test | Rule A | Rule B | Rule C (tile / score) |
+|---|---|---|---|
+| T1 | 4 | 4 | 4 / 2 |
+| T2 | 4 | 16 | 4 / 4 |
+| T3 | 16 | 16 | 16 / 4 |
+| T4 | 16 | 32 | 16 / 5 |
+| T5 | **16** | **512** | 16 / 9 |
+| T6 | 64 | 256 | 64 / 7 |
+| T7 | 256 | 256 | 256 / 3 |
+| T8a | 8 | 8 | 8 / 3 |
+| T8b | 8 | 16 | 8 / 4 |
+
+Audit findings:
+
+- **Rule A:** Strong on simplicity and decision integrity. Weak on "same-value extensions feel valuable" — they're bridges only, not directly rewarded. Long same-value chains (e.g., T2) are *strictly worse* than running multiple shorter chains.
+- **Rule B:** Fails dominant strategy test. Length-hunting collapses the game — players hunt for longest chain regardless of composition. Doubling extensions become irrelevant (any extension equally good). Crazy values (T5 → 512) escape the chain's actual tile values. **Rejected.**
+- **Rule C:** Strongest analytically — both tradeoffs alive on separate channels. But adds complexity (two reward channels, requires score to feel meaningful in every mode).
+
+#### Step 1.2d — Designing Rule D family
+
+User reaction: "I liked Rule B but the values were crazy." Diagnosed the issue: Rule B's *intent* is right (length should pay) but exponential growth is the bug.
+
+Introduced **Rule D** — parameterized family where every k same-value extensions count as one extra doubling:
+
+> result = start × 2^(d + ⌊s / k⌋ + 1)
+
+Equivalently: result = last × 2 × 2^⌊s/k⌋
+
+Parameter k is the knob:
+- k = ∞: Rule A (same-values worthless for tile)
+- k = 4: every 4 same-values = 1 bonus doubling. Subtle.
+- k = 3: every 3 same-values = 1 bonus doubling. Modest.
+- k = 2: every 2 same-values = 1 bonus doubling. Strong.
+- k = 1: Rule B (same-values = full doubling each)
+
+Comparison on test chains for k=2 and k=3:
+
+| Test | Rule A | Rule B | D, k=3 | D, k=2 |
+|---|---|---|---|---|
+| T2 | 4 | 16 | 4 | 8 |
+| T4 | 16 | 32 | 16 | 16 |
+| T5 | 16 | 512 | 32 | 64 |
+| T6 | 64 | 256 | 64 | 128 |
+| T8b | 8 | 16 | 8 | 8 |
+
+#### Decision: Rule D with k = 2
+
+**Rationale:**
+- Honors user's instinct that length should pay aggressively
+- Bounded math (T5 → 64, not 512)
+- Doublings remain the strongest single move (each = full extra tier)
+- Same-value extensions valuable in *pairs* (every two = one extra tier)
+- Single isolated same-value extensions are essentially "free" but don't directly pay (still useful as bridges)
+- Long same-value runs become genuinely rewarding
+
+**Alternatives considered:**
+
+| Alternative | Why not chosen |
+|---|---|
+| Rule A | Same-value extensions feel wasted; T2 problem |
+| Rule B | Dominant strategy (length-hunting); crazy values |
+| Rule C | Adds dual-currency complexity; max tile = score in user's framing |
+| Rule D, k = 3 | More conservative; might feel stingy on same-values |
+| Bonus content for long chains | More content-design than rule design; can be added later as Layer 2 |
+| Soft retirement | Considered but the mechanic's discreteness preferred for clarity |
+
+**Status:** Soft commitment. Will watch in playtest:
+- If players over-index on hunting long chains → ratchet toward k = 3
+- If long chains feel under-rewarded → consider k = 1.5 (every 1.5 same-values, requires non-integer math) or stay with k = 2 plus content bonuses
+
+**Important property to preserve:** Result rule should NOT vary between modes — that breaks game identity.
+
+### Step 1.3 — Default grid size
+
+**Decision:** 6 columns × 7 rows = 42 cells, portrait orientation.
+
+**Reference points considered:**
+
+| Game | Grid |
+|---|---|
+| 2048 / Threes! | 4×4 |
+| Triple Town | 6×6 |
+| Drop7 | 7×7 |
+| Bejeweled | 8×8 |
+| Candy Crush | ~9×9 |
+
+**Rationale:**
+- 4×4 too tight — chains of 5-9 wouldn't have room
+- 5×5 borderline — heavily constrains paths
+- 6×7 sweet spot — enough room for ambitious chains, scannable in one glance
+- 7×7+ starts sprawling; mental scan load increases
+- Portrait orientation: gravity drops top-to-bottom, mobile screens are taller than wide, gives reservoir for chain development
+
+**Knob range across modes:** ~5×6 (tight, Ascension challenges) to ~7×8 (loose, Drift cozy).
+
+**Status:** Confirmed. Will revisit if playtest shows specific scaling problems.
+
+### Step 1.4 — Spawn distribution (initial decision, then revised)
+
+#### Initial decision
+
+**Pool:** 2-256 (user's stated values)
+**Weights:** 1/value (power-law decay) — each tier half as likely as previous
+**Rate:** L−1 new tiles after each chain of length L (proportional to chain length, an emergent pacing property)
+**Position:** Top of empty columns after gravity
+**Evolution:** Static (revisit later)
+
+Concrete weights:
+
+| Value | Weight | Probability |
+|---|---|---|
+| 2 | 0.5 | ~50% |
+| 4 | 0.25 | ~25% |
+| 8 | 0.125 | ~13% |
+| 16 | 0.0625 | ~6% |
+| 32 | 0.031 | ~3% |
+| 64 | 0.016 | ~2% |
+| 128 | 0.008 | ~1% |
+| 256 | 0.004 | ~0.4% |
+
+Expected board composition on full 42-cell grid: ~21 cells of 2, ~10-11 of 4, ~5 of 8, ~3 of 16, ~1 of 32, occasional 64s, rare 128s and 256s.
+
+**Alternatives considered:**
+
+| Alternative | Why not initially chosen |
+|---|---|
+| Uniform across 2-256 | Adjacent same-value pairs become rare; chain starts dry up |
+| Bottom-only (2/4/8 only) | Would simplify but doesn't honor stated 2-256 pool |
+| Steeper power-law (1/value²) | Higher tiles too rare to feel like real spawns |
+| Dynamic Threes!-style unlock | More complex, but flagged as future option |
+
+#### Revision (introduced by user): tile retirement mechanic
+
+User proposed: **when player reaches a new max tile, the lowest-tier value in spawn pool retires permanently.** Existing instances on board remain until cleared.
+
+**Why this is a strong design move:**
+
+1. **Solves spawn pool drift** — keeps spawn pool focused on relevant range as player climbs
+2. **Solves late-game flatness** — boards don't become cluttered with every value ever
+3. **Couples micro and meta gameplay** — chain decisions affect strategic readiness for upcoming progression
+4. **Creates new strategic axis: anticipating progression** — before reaching a new max tile, player asks "are soon-to-be-retired tiles in chainable clusters or stranded?"
+5. **Synergies with Rule D, k=2** — incentivizes long same-value chains right before milestones, exactly what Rule D rewards
+
+**Strategic implications:**
+
+- **Stranding becomes a slow-poison failure mode.** Stranded retired tiles consume cells permanently, shrinking effective board size, raising death pressure over time.
+- **Pre-milestone behavior emerges.** Predictable rhythm: chain freely → approach milestone → tidy up → push through → recover → repeat. This cadence is exactly the meta-pacing pattern of great cult-favorite games.
+- **Spawn distribution becomes dynamic by design.** The static 1/value plan becomes a *staged* system: weights still ~1/value, but the *pool itself* shifts as retirement fires.
+
+#### Step 1.4 final design (settled)
+
+After working through the open design questions, the finalized retirement spec is:
+
+**Trigger model — "next tier above current spawn ceiling"**
+
+- Initial spawn pool: 2-256 (ceiling = 256, eight tiers)
+- First retirement fires when player reaches **512** (next tier above 256). 512 is the first major goal.
+- At that moment: 2s retire, sliding window slides — pool becomes 4-512
+- Next retirement fires when player reaches 1024 → 4s retire, pool becomes 8-1024
+- Etc. Pool always stays 8 tiers wide.
+
+**Why this trigger model (chosen over fixed multiplier rules like 8×):**
+
+1. First retirement is a real milestone — reaching 512 takes meaningful play (likely 50+ chains)
+2. Retirement fires at the moment of "graduation" — reaching above the spawn ceiling is itself a player achievement
+3. No explicit grace period mechanic needed — entire pre-512 game IS the implicit grace
+4. Self-pacing — the trigger moves with the player, naturally skill-correlated
+5. Generalizes cleanly to higher tiers — each retirement fires at "next tier above ceiling"
+6. Honors the user's instinct that "first max tile takes them a few turns"
+
+Rejected: 4× / 8× / 16× fixed multiplier triggers (too aggressive at low tiers; arbitrary timing).
+Rejected: Fixed move count triggers (decouples retirement from skill — wrong frame).
+
+**Retirement type — hard**
+
+When a tier retires, it never spawns again. No soft retirement (continued rare spawns) — would dilute the mechanic.
+
+**Pool size dynamics — sliding window, 8 tiers wide**
+
+Pool always maintains 8 distinct tiers. As bottom retires, new top tier joins at low frequency (the new tier becomes the rarest in the spawn pool, replacing the previous rarest's role).
+
+Why 8 tiers (not 4 or 5): more variety throughout play, more enjoyable. The spawn algorithm (1/value weighting) does the difficulty work, not the pool size.
+
+**Stranded tile fate — stay as normal tiles (emergent blockers)**
+
+Retired tiles stay on the board, behave by normal chain rules. *No special handling needed.*
+
+The stranding-as-blocker behavior emerges automatically:
+- Two adjacent retired tiles: still chainable (start a chain with them as normal)
+- One isolated retired tile: cannot be cleared. Why? Chain start requires two adjacent same-values (no new ones spawn). And no chain can extend *to* a lower-tier retired tile from a higher tile (extension rule is "same OR doubled" — a 4 can't extend to a 2 because 2 is half, not double).
+- Result: isolated retired tiles effectively become permanent blockers, but it's emergent from existing rules rather than a special-case mechanic.
+
+The grace period is the player's window to *avoid* stranding by chaining through low-tier tiles before they retire.
+
+**No explicit grace period UX (yet)**
+
+The mechanic doesn't need an explicit warning state in the kernel — the entire pre-threshold game is the implicit grace. We can layer explicit grace UX on top later if playtest shows players are surprised by retirements.
+
+**Per-mode availability**
+
+| Mode | Retirement state |
+|---|---|
+| Endless | On (default trigger model) |
+| Drift (cozy) | Off — cozy shouldn't strand |
+| Ascension | On, possibly intensified (modifier could shorten grace, or use 4× trigger) |
+| Levels | Overridden by designed boards (level designer controls state) |
+
+**Status:** Settled. All sub-decisions confirmed.
+
+**Honest cost of adopting:**
+- Increased prototype complexity (track max tile, spawn ceiling, sliding window state)
+- Tuning surface area grows (weights at each stage, not just initial)
+- Harder to remove later than to add later
+
+**Build sequencing:** Tile retirement is part of v1.5, not v1. The bare chain mechanic (without retirement) is v1, which validates the kernel before we add the retirement layer.
+
+### Step 1.5 — Kernel audit against six pillars (COMPLETED)
+
+**Purpose:** Walk through each of the six pillars of beloved games (see Concepts §5) and audit the current kernel against each. Identify weaknesses to address either now (mechanic tweak), in v1.5+ (content/juice work), or accept and watch in playtest. Audit happens *before* prototype because mechanic-level fixes are much cheaper now than after the prototype is built.
+
+#### Pillar 1 — Depth that reveals slowly
+
+*Strengths.* The chain mechanic activates 6-7 of the 8 named tradeoff classes simultaneously — that's structurally rare. Same-value extensions as path bridges is a non-obvious insight that takes 20-50 games to internalize. Rule D, k=2 creates real strategic distinction between climbing chains, clearing chains, and bridging chains. Retirement adds a meta-strategic layer that compounds with chain-decisions.
+
+*Weaknesses.* Without retirement (v1), the game may feel "samey" after 30-60 minutes — retirement is the meta-rhythm. Powers-of-2 progression is well-trodden ground; players will arrive with mental models from 2048.
+
+**Verdict:** Strong (with v1.5 retirement layer). Adequate for v1 alone.
+
+**Action items:**
+- Watch in v1 playtest: does the bare chain mechanic stay fresh for 30+ minutes?
+- Confirmed v1.5 priorities: retirement is the depth multiplier, not a polish feature
+
+#### Pillar 2 — Interesting decisions every move
+
+*Strengths.* Non-trivial boards typically offer 3-5 plausible chain starts. Once started, every extension is a real choice. Chain placement matters because the result tile lands at the last position. Stranding risk adds pressure.
+
+*Weaknesses.* In sparse early-game boards, choices may collapse to 1-2 forced chains. In late game with heavy stranding, the board may lock into limited options. The "must start with adjacent same-value pair" requirement creates moments where the only chain is forced.
+
+**Verdict:** Strong in mid-game; Watch for early-game and locked-board states.
+
+**Action items:**
+- Watch in playtest: are there sustained periods where chains feel forced?
+- If forced-chain states are common: consider tweaking spawn distribution to ensure adjacent same-value pairs always exist
+
+#### Pillar 3 — Failure that teaches
+
+*Strengths.* Loss condition is concrete and visible — "no two adjacent same-value tiles" — and the player can see this on the death board. Stranding-from-retirement creates clear failure narratives. Chain-finding is a teachable skill.
+
+*Weaknesses.* Without explicit UX, surprise retirement events feel arbitrary. RNG-related deaths could feel "unfair." Players might not understand *why* a particular chain choice was suboptimal.
+
+**Verdict:** Adequate for v1; needs work in v1.5+ for retirement.
+
+**Action items:**
+- v1.5 priority: visual feedback when retirement is approaching (highlight retiring tiles, "tier graduated" moment)
+- v1.5 priority: visual treatment of the death state (clearly show why no chain is possible)
+- v2+ idea: post-game replay or "what you missed" hints
+- Watch in playtest: are deaths feeling fair or arbitrary?
+
+#### Pillar 4 — Felt mastery curve
+
+*Strengths.* Multiple distinct skill axes — chain length, climb-vs-clear judgment, board management, retirement timing. Each has clear improvement trajectory. Skills transfer between games. Max tile reached is a natural personal record.
+
+*Weaknesses.* Without recorded stats, players can't see improvement objectively. Without comparisons (personal best, leaderboards), mastery is purely internal feeling.
+
+**Verdict:** Adequate for v1; needs explicit reinforcement in v2+.
+
+**Action items:**
+- v1: track current-game stats (max tile, chains made, longest chain) — no persistence needed
+- v2+ priority: persistent stats tracking (lifetime best max tile, longest chain ever, total games played)
+- v3+ idea: achievements (first 1024, longest chain, etc.)
+- Accept for v1: purely internal mastery feel is fine for first prototype
+
+#### Pillar 5 — Aesthetic identity
+
+*Strengths.* The chain mechanic offers strong visual potential — animated chain paths, dramatic doubling moments, retirement set-pieces. The "next tier above ceiling" milestone (first time = 512) is a clear narrative moment.
+
+*Weaknesses.* **Biggest current gap.** No aesthetic identity yet — explicitly deferred to v2.5. Risk: a generic implementation looks like "2048 variant" forever. Without distinctive visuals/audio, the chain mechanic's novelty is invisible to anyone who doesn't already understand the rules.
+
+**Verdict:** Deferred — biggest known gap. Acceptable for v1 (placeholder visuals), but must be addressed seriously in v2.5.
+
+**Action items:**
+- v1: use intentionally minimal/placeholder visuals (don't fake polish — fake polish hides what needs work)
+- v2.5: significant design work required. Possible directions to explore:
+  - Mechanical/kinetic aesthetic (numbers as physical objects)
+  - Themed numbers (real-world objects matching tier values)
+  - Abstract geometric (Threes!-style minimalist)
+  - Generative/mathematical art aesthetic
+- Note: aesthetic identity directly influences which archetype the game lands as — cult favorites have intense aesthetics
+
+#### Pillar 6 — Honest reward structure
+
+*Strengths.* Rule D, k=2 ensures result tiles correlate strongly with chain quality. Power-law spawn weights ensure low-tier tiles dominate, keeping chain starts available. Death state is skill-correlated. Chain mechanic is purely cognitive.
+
+*Weaknesses.* Spawn variance could theoretically punish skilled play in edge cases. Retirement timing has some luck dependency in early game. Rare high-tile spawns could distort early-game strategy.
+
+**Verdict:** Strong. RNG bounded by skill; luck contributes but doesn't dominate.
+
+**Action items:**
+- Watch in playtest: are bad-luck losses common enough to feel arbitrary?
+- v3+ option: seeded daily challenge (Ascension mode) for deterministic skill comparison
+
+#### Audit summary
+
+| Pillar | v1 verdict | Biggest gap |
+|---|---|---|
+| 1. Depth that reveals slowly | Adequate (Strong with retirement) | Need v1.5 retirement to hit "strong" |
+| 2. Interesting decisions every move | Strong | Watch for forced-chain edge cases |
+| 3. Failure that teaches | Adequate | Need retirement UX in v1.5 |
+| 4. Felt mastery curve | Adequate | Need persistent stats in v2+ |
+| 5. Aesthetic identity | **Deferred** | **Biggest known gap** — must address in v2.5 |
+| 6. Honest reward structure | Strong | Watch RNG variance in playtest |
+
+**Overall:** The kernel is structurally sound and ready to prototype. No fundamental mechanic changes needed. The two biggest gaps are explicit (aesthetic deferred to v2.5; mastery feedback deferred to v2+) — both deferred deliberately.
+
+**Three priority callouts:**
+
+1. **The bare chain mechanic must hold for 30+ minutes alone in v1 playtest.** If it doesn't, no retirement layer or content will save it. The audit suggests it should — but this is the single load-bearing assumption.
+2. **Aesthetic identity work in v2.5 is critical, not cosmetic.** A generic implementation will be perpetually compared to 2048.
+3. **Retirement UX in v1.5 needs careful design.** The mechanic is rich but invisible without proper visual treatment.
+
+**Phase 1 status:** Complete. Ready to move to Phase 2 (Build and play).
+
+## Phase 2 — Build and play (next phase)
+
+Confirmed: **only Endless mode is built for v1.** Hero mode validates kernel; other modes are spec'd but deferred.
+
+The full staged build roadmap lives in the *Specification* document. Quick summary here for journal context:
+
+| Stage | What's in it | Goal |
+|---|---|---|
+| **v1** | Bare chain Endless: grid + tiles + chain rule + Rule D k=2 + 1/value spawning, no retirement, no special tiles | Does the chain mechanic feel fun for 30+ minutes? |
+| **v1.5** | Add tile retirement (next-tier-above-ceiling trigger, sliding window, stay-as-tiles) | Does retirement add depth or noise? |
+| **v2** | Add Layer 2 content (special tiles, wilds, blockers, multipliers) | Does content deepen the game without distorting it? |
+| **v2.5** | Add juice and aesthetic identity | Does it become a *thing*? |
+| **v3+** | Add Levels mode (objectives, level design, currency) | Does the kernel survive content-driven progression? |
+| **v4+** | Add Ascension mode (modifiers, daily challenges) | Does the kernel hold under modifier extremes? |
+| **v5+** | Add Drift mode (cozy parameters, retirement off, soft visuals) | Does the kernel work as a cozy experience? |
+
+Each stage is a **gate**: do not proceed if the prior stage didn't land.
+
+### Phase 2 sub-steps (for v1 specifically)
+
+- 2.1 Consult UX/UI lens before any visual work
+- 2.2 Prototype bare core mechanic (no retirement, no content elements yet)
+- 2.3 Play it. Decide if it's fun *before* adding anything
+
+## Phase 3 — Iterate or layer up (DEFERRED)
+
+- 3.1 If mechanic isn't fun: tune mechanic. *Do not add content to fix a broken mechanic.*
+- 3.2 If mechanic is fun: proceed to v1.5 (add retirement)
+- 3.3 Continue staged rollout per build roadmap above
+
+---
+
+
+---
+
+# AUDIT AND REVISIT NOTES
+
+This section captures the *living watchlist* — soft commitments with revisit triggers, things considered and rejected, things deliberately deferred, things to verify in playtest, and things explicitly out of scope. Update as decisions are made or revisited.
+
+## Decisions explicitly held as soft commitments
+
+| Decision | Revisit if |
+|---|---|
+| Result rule = Rule D, k=2 | Playtest shows length-hunting dominates → consider k=3 |
+| 6×7 portrait grid | Playtest shows scaling problems |
+| Spawn weights = 1/value | Stages feel imbalanced under retirement |
+| 8-tier spawn pool size | Variety feels overwhelming or insufficient |
+| Endless as hero mode | Bare prototype reveals fundamental mechanic problems |
+| Hard retirement | Stranding feels too punishing in playtest |
+| Trigger = next tier above ceiling | First retirement at 512 feels too late or too early |
+| No explicit grace period UX | Players are surprised by retirements (would suggest adding warning state) |
+| Stranded tiles stay as normal tiles | Permanent blockers feel arbitrary or unfair (would suggest auto-clear or convert-to-special) |
+
+## Things considered and rejected
+
+| Rejected | Why |
+|---|---|
+| Rule B (start × 2^L−1) | Dominant strategy (length-hunting collapses game); crazy values escape chain's tile values |
+| Daily ritual archetype | User explicitly excluded |
+| Uniform spawn distribution across 2-256 | Adjacent same-value pairs too rare; chain starts dry up |
+| Same-value extensions count as full doublings (Rule B disguised) | Same problem as Rule B |
+| Prototype most-constrained mode (Levels) first | Bare mechanic must prove itself before constraints are added |
+| Auto-clearing stranded retired tiles | Would collapse the strategic axis retirement creates |
+| Fixed-multiplier retirement triggers (4× / 8× / 16×) | Too aggressive at low tiers; arbitrary timing decoupled from player progression |
+| Move-count-based retirement triggers | Decouples retirement from skill — wrong frame for our game |
+| Soft retirement (continued rare spawns of retired tier) | Would dilute the mechanic's clarity |
+| 4-tier narrow spawn pool | Less variety, less enjoyable; algorithm should do difficulty work, not pool size |
+| Prototyping multiple modes simultaneously in v1 | Wastes effort if kernel turns out broken; modes are modifications of validated Endless |
+
+## Things deliberately deferred (with note on when to revisit)
+
+| Deferred | When to revisit |
+|---|---|
+| Layer 2 content design | After Endless v1 plays well for 30+ minutes |
+| Specific Levels content | After Layer 2 element library exists |
+| Ascension modifier system | After Endless and Levels both function |
+| Drift parameters | When ready to expand mode roster |
+| Score system beyond max-tile | After playtest reveals whether length-bonus is needed |
+| Game feel / juice | After core mechanic validated as fun |
+| Aesthetic identity | After mechanic is settled enough that visuals can support it |
+
+## Things to verify in playtest
+
+**v1 (bare chain Endless) — verify before adding retirement:**
+- Whether Rule D, k=2 produces interesting decisions throughout a 30-minute session
+- Whether long same-value chains feel rewarded or "wasted" relative to short doubling chains
+- Whether 6×7 grid feels too tight, just right, or too sprawling
+- Whether spawn weights produce enough chain starts without making the game trivial
+- Whether the loss condition (no adjacent same-value pair) creates fair deaths or arbitrary ones
+- Whether 8 active tiers feels enjoyable or overwhelming
+
+**v1.5 (retirement layered in) — verify after adding retirement:**
+- Whether reaching 512 takes "a few turns" of meaningful play (not too fast, not too slow)
+- Whether stranding creates good strategic tension or bad frustration
+- Whether the milestone-rhythm pacing is satisfying
+- Whether players notice and adapt to incoming retirements without explicit UX
+- Whether 8-tier sliding-window pool stays varied as the game progresses
+
+## Things explicitly NOT in scope yet
+
+- Monetization model — entire question deferred until we know what game we have
+- Platform decision (web/iOS/Android/native) — currently planning web prototype but final platform open
+- Multiplayer / social — not part of any current mode
+- Narrative or character — not part of any current mode
+- Live ops / content pipeline — only relevant once at scale
+
+---
+
+*End of document. Living document — update as decisions are made or revisited.*
+
+---
+
+*End of Design Journal. Companion to the Specification (which captures current settled state).*

--- a/docs/Merge_Game_Specification.md
+++ b/docs/Merge_Game_Specification.md
@@ -1,0 +1,124 @@
+# Merge Game Specification
+
+**Status:** Living document — current state of the design
+**Audience:** Designer (Evan), engineering collaborators, future builders
+**Use case:** "What does the game do? What should I build?"
+**Updates:** Every time a decision is settled or revised
+**Last updated:** Phase 1 complete — kernel audit passed
+
+**Companion documents:**
+- *Game Design Concepts & Frameworks* — vocabulary and frameworks referenced below
+- *Merge Game Design Journal* — full decision log and audit notes for this spec
+
+---
+
+## How to use this document
+
+This is the **current contract** for what the game is. It contains only what's true *right now* — no historical baggage, no rejected alternatives, no narrative. When you need to know what to build, read this. When something gets settled or revised, this updates.
+
+If you need to know *why* something is the way it is, see the **Design Journal** for the decision narrative and audit notes.
+
+If you need to know what a term means (kernel, knob, archetype, six pillars, etc.), see the **Concepts** document.
+
+---
+
+## Project overview
+
+The merge game is a 2D number-merging puzzle in the casual puzzle genre, designed as a **multi-mode** game with a shared kernel and mode-specific knobs. It blends three established merge-game lineages (Threes!, 2048, Drop7) into a chain-based mechanic with two extension rules (same-value or doubled-adjacent) and a result rule that rewards both chain length and tier-climbing.
+
+**Working title:** TBD (project codename: "merge game")
+**Target platform:** Web (mobile-first portrait orientation), final platform open
+**Optimization target:** Affection and mastery satisfaction — not engagement metrics
+
+---
+
+## Mode roster
+
+| Mode | Archetype | Status |
+|---|---|---|
+| **Endless** | Cult favorite | **Hero mode** — design first, polish first. v1 of all builds. |
+| **Levels** | Mass casual | Deferred to v3+; Layer 2/3 content design required |
+| **Ascension** | Hardcore mastery | Deferred to v4+; modifier system to design |
+| **Drift** | Cozy / chill | Deferred to v5+; soft-pacing parameters to define |
+
+For v1 prototype: only **Endless** is built.
+
+---
+
+## Settled kernel (invariant across all modes that have it)
+
+| Element | Specification |
+|---|---|
+| Chain start | 2 adjacent same-value tiles (8-way adjacency) |
+| Chain extension | Same-value OR doubled-adjacent tile (8-way) |
+| Tile reuse | Not allowed within a chain |
+| Chain end | Voluntary; chain resolves to single result tile at last position |
+| Result rule | **Rule D, k=2:** result = last × 2 × 2^⌊s/2⌋ where s = same-value extensions beyond initial pair |
+| Tile system | Powers of 2: 2, 4, 8, 16, 32, ... |
+| Result placement | Last position in chain; other chain tiles disappear |
+| Post-chain | Gravity drops; new tiles spawn from top of empty columns |
+| Goal | Reach max-tile milestones |
+| Loss condition | No legal chain start (no adjacent same-value pair) |
+| **Tile retirement — trigger** | Reach next tier above current spawn ceiling (first time = 512) |
+| **Tile retirement — type** | Hard (no soft fallback) |
+| **Tile retirement — pool dynamics** | Sliding window, 8 tiers wide, new top joins as bottom retires |
+| **Tile retirement — stranded fate** | Stay as normal tiles; isolated retirees become emergent blockers |
+
+## Settled knobs (vary by mode)
+
+| Knob | Default (Endless) | Range across modes |
+|---|---|---|
+| Grid dimensions | 6×7 portrait | 5×6 (tight Ascension) to 7×8 (loose Drift) |
+| Spawn pool initial range | 2-256 (8 tiers) | Restrict per mode |
+| Spawn weights | 1/value power-law | Stage-dependent under retirement |
+| Spawn rate | L−1 per chain | Continuous timer for Drift |
+| Starting board state | Random per spawn weights | Designed for Levels |
+| Win conditions | Open-ended (max tile / score) | Tile target, score target, clear, collect, etc. for Levels |
+| Loss conditions | Death on (no chain start) | Death off for Drift |
+| Move/time limits | None | Mode-specific |
+| Special tile sets | None | None / basic / advanced (Layer 2) |
+| Score formula | (Pending — currently max tile = score) | Per mode |
+| Combo / chain bonuses | (Pending) | Per mode |
+| Visual / audio palette | (Pending) | Cozy soft vs hardcore sharp |
+| Tile retirement on/off | On | On for Endless/Ascension; off for Drift; overridden for Levels |
+| Tile retirement trigger | Next tier above ceiling | Could intensify in Ascension (e.g., 4× rule) |
+
+## Staged build roadmap
+
+Confirmed: **only Endless mode is built for v1.** Hero mode validates kernel; other modes are spec'd but deferred.
+
+| Stage | What's in it | Validation goal |
+|---|---|---|
+| **v1** | Bare chain Endless: grid + tiles + chain rule + Rule D k=2 + 1/value spawning, no retirement, no special tiles | Does the chain mechanic feel fun for 30+ minutes? |
+| **v1.5** | Add tile retirement (next-tier-above-ceiling trigger, sliding window, stay-as-tiles) | Does retirement add depth or noise? |
+| **v2** | Add Layer 2 content (special tiles, wilds, blockers, multipliers) | Does content deepen the game without distorting it? |
+| **v2.5** | Add juice and aesthetic identity | Does it become a *thing*? |
+| **v3+** | Add Levels mode (objectives, level design, currency) | Does the kernel survive content-driven progression? |
+| **v4+** | Add Ascension mode (modifiers, daily challenges) | Does the kernel hold under modifier extremes? |
+| **v5+** | Add Drift mode (cozy parameters, retirement off, soft visuals) | Does the kernel work as a cozy experience? |
+
+Each stage is a **gate**: do not proceed if the prior stage didn't land.
+
+For full rationale on the build sequencing, see *Design Journal* — Phase 2 section.
+
+## Open decisions
+
+**Phase 1: Complete.** All design decisions for the kernel are settled. Kernel audit passed (see Journal §1.5).
+
+**Phase 2: Pending start.** Build a prototype of Endless v1 (bare chain mechanic, no retirement, no content). Validate that the chain mechanic feels fun for 30+ minutes. UX/UI lens consultation precedes any visual work.
+
+## Deferred to later phases
+
+- All Layer 2 content design (special tiles, blockers, wilds, multipliers) — v2+
+- All Layer 3 objectives design (level structure, win conditions per mode) — v3+
+- All Layer 4 meta-progression and economy — v3+
+- All Layer 5 game feel / juice — v2.5+
+- Visual / aesthetic identity — v2.5+ (biggest known gap from kernel audit)
+- Cross-mode parameter sets (full Ascension modifier system, Drift cozy parameters, Levels content) — v3+
+- Onboarding / tutorialization design — v3+
+- Score formula beyond "max tile = score" — TBD pending playtest
+- Persistent stats tracking — v2+ (mastery-curve action item from audit)
+
+---
+
+*End of Specification. For decision rationale, audit notes, and revisit triggers, see the Design Journal.*

--- a/docs/Merge_Game_Tooling_Journal.md
+++ b/docs/Merge_Game_Tooling_Journal.md
@@ -1,0 +1,136 @@
+# Merge Game Tooling Journal
+
+**Status:** Living document — process record for tooling design
+**Audience:** Designer (Evan), future-self auditing decisions
+**Use case:** "Why did we choose X for the tools?" / "What did we consider and reject?" / "What should I revisit?"
+**Updates:** Each time a tooling design decision is discussed
+**Last updated:** Phase 0 complete; Phase 1 in progress
+
+**Companion documents:**
+- *Game Design Concepts & Frameworks* — Part B (Sections 17-25) is the vocabulary
+- *Merge Game Tooling Specification* — current settled state of the tooling design
+- *Merge Game Specification* and *Merge Game Design Journal* — the game project these tools serve
+
+---
+
+## How to use this document
+
+This is the **process record** for tooling design — the meeting minutes of tooling design conversations. It contains:
+
+- **Phase-by-phase narrative** of decisions made for the tooling, including alternatives considered
+- **The tooling audit** against tool-design criteria (when complete)
+- **Soft commitments** with revisit triggers
+- **Things rejected** and why
+- **Things deferred** with notes on when to revisit
+- **Things to verify in tooling playtest**
+
+When auditing a past decision: find the relevant Phase/Step in the narrative, see the alternatives we considered and the rationale, then decide whether new information changes the answer. If you change a decision, update the *Tooling Specification* and add a note here explaining what changed and why.
+
+---
+
+## Process framing
+
+Same shape as the game design process:
+
+1. Identify the open decision
+2. State happy-path assumptions / defaults
+3. Surface candidate options
+4. Apply criteria + analysis
+5. Pick (or defer with explicit reasoning)
+6. Note what we'd revisit and under what conditions
+
+Soft commitments — ideas as working assumptions we proceed under, flag as revisitable, and revisit when new info arrives.
+
+---
+
+## Phase 0 — Tooling concepts (COMPLETED)
+
+Captured nine concept sections (17-25) in the Concepts document covering:
+
+- The role of internal tools in game design
+- Tool archetypes (designer's microscope, team's dashboard, QA's stress rig, researcher's instrument, public playground)
+- Single source of truth (the load-bearing tooling principle)
+- Instrumentation principles
+- Parameter exposition (Tier 1/2/3)
+- Simulation harness patterns (strategies, runners, analyzers)
+- Failure modes specific to tooling
+- The "build less, build well" discipline
+- Forward and inverse modes (with three approaches to inverse)
+
+Key load-bearing concepts identified:
+- **Section 19 (single source of truth)** — most important architectural decision
+- **Section 21 (parameter exposition tiers)** — load-bearing for tuning console design
+- **Section 25 (forward/inverse unified data model)** — affects Stage B/E architecture from day one
+- **Section 23 (failure modes)** — keep visible during build
+
+Decisions made during Phase 0:
+
+- **Tooling will be three tools, not one:** Tuning Console (Stage A), Sim Harness (Stage B), Design Intent Solver (Stage E)
+- **Single user (Evan) for v1**, with playtester and researcher modes deferred
+- **Stages C (replay) and D (sandbox) deferred** — not part of current scope
+- **Architecture: shared pure-logic module** between playable game and all tools (single source of truth)
+- **Sim harness data model designed for inverse querying from day one** (insight from Section 25)
+
+## Phase 1 — Pin down enough to build (IN PROGRESS)
+
+Planned steps:
+
+- 1.1 Tool architecture decisions (how does tool relate to game? embedded vs separate? single app vs multiple?)
+- 1.2 Parameter exposition — which parameters are Tier 1 / Tier 2 / Tier 3?
+- 1.3 Tuning Console design (Stage A specifics)
+- 1.4 Simulation Harness design (Stage B specifics)
+- 1.5 Design Intent Solver design (Stage E specifics)
+- 1.6 Audit against tool design criteria
+
+*(To be populated as decisions are made.)*
+
+## Phase 2 — Build (DEFERRED until Phase 1 complete)
+
+Will integrate with the game v1 prototype build path. Specific build sequencing TBD in Phase 1.
+
+---
+
+# AUDIT AND REVISIT NOTES
+
+This section captures the *living watchlist* — soft commitments with revisit triggers, things considered and rejected, things deliberately deferred. Update as decisions are made or revisited.
+
+## Decisions explicitly held as soft commitments
+
+| Decision | Revisit if |
+|---|---|
+| Three tools (A, B, E) — not C or D | Need to reproduce specific board states (would suggest C); start designing Levels content (would suggest D) |
+| Designer-only v1 | Want playtester feedback before mechanic is settled (would add playtester variant) |
+| Approach 1 (sweep + filter) for inverse mode | Sweep proves too slow; parameter space proves too large |
+
+## Things considered and rejected
+
+| Rejected | Why |
+|---|---|
+| Building all five stages (A-E) at once | Procrastination trap; tools should answer specific questions, not preempt |
+| Tools and game in separate codebases | Simulation drift risk too high; single source of truth is non-negotiable |
+| Surrogate models / Bayesian optimization for inverse mode | Approach 1 should suffice for our scale; reserve as upgrade path |
+
+## Things deliberately deferred (with notes on when to revisit)
+
+| Deferred | When to revisit |
+|---|---|
+| Stage C (replay / session recording) | When first non-Evan playtester arrives (v2+) |
+| Stage D (sandbox / state setup) | When designing Levels content (v3+) |
+| Public-facing tool variant | If/when there's an audience beyond Evan |
+| AI / LLM-based player strategies | If heuristic strategies prove inadequate |
+| Real-time telemetry dashboard | After single-config sim runner exists |
+
+## Things to verify in tooling validation
+
+*(To be populated during Phase 1 and 2.)*
+
+## Things explicitly NOT in scope yet
+
+- Tool monetization or distribution — this is internal infrastructure
+- Multi-user / collaborative features — single user only
+- Cloud / hosted versions — runs in browser locally
+- Authentication / security model — not a public tool
+
+---
+
+*End of Tooling Journal. Companion to the Tooling Specification.*

--- a/docs/Merge_Game_Tooling_Specification.md
+++ b/docs/Merge_Game_Tooling_Specification.md
@@ -1,0 +1,63 @@
+# Merge Game Tooling Specification
+
+**Status:** Living document — current state of the tooling design
+**Audience:** Designer (Evan), engineering collaborators
+**Use case:** "What do the tools do? What should I build?"
+**Updates:** Every time a tooling decision is settled or revised
+**Last updated:** Phase 0 complete (concepts captured); Phase 1 in progress
+
+**Companion documents:**
+- *Game Design Concepts & Frameworks* — Part B (Sections 17-25) covers tooling concepts referenced here
+- *Merge Game Tooling Journal* — full decision log and audit notes for these tooling decisions
+- *Merge Game Specification* — the game design these tools support
+
+---
+
+## How to use this document
+
+This is the **current contract** for what the tooling does. It contains only what's true *right now* — no historical baggage, no rejected alternatives, no narrative. When you need to know what to build, read this. When something gets settled or revised, this updates.
+
+If you need to know *why* something is the way it is, see the **Tooling Journal** for the decision narrative and audit notes.
+
+If you need to know what a term means (forward/inverse mode, tier exposition, simulation harness patterns, etc.), see the **Concepts** document — Part B.
+
+---
+
+## Project overview
+
+The tooling project supports the merge game's design and tuning work. It's a set of three related tools sharing common infrastructure (the pure-logic game module from Section 19).
+
+**Primary user (v1):** Designer (Evan)
+**Future users:** Playtesters, researcher-self for batch experiments
+**Target platform:** Web (same browser environment as the game)
+**Architecture model:** Single source of truth — pure game logic shared between playable game, tuning console, and simulation harness
+
+## Tool roster
+
+| Tool | Stage | Mode | Status |
+|---|---|---|---|
+| **Tuning Console** | A | Forward, live | **Hero tool** — design first, build alongside game v1 |
+| **Simulation Harness** | B | Forward, batch | Built after game v1 fun-validated |
+| **Design Intent Solver** | E | Inverse, structured query | Built on top of Stage B; data model designed to support this from start |
+
+Stages C (replay) and D (sandbox) deliberately deferred — not part of current scope.
+
+For full rationale, see *Tooling Journal*.
+
+---
+
+## Settled decisions
+
+*(To be populated during Phase 1.)*
+
+## Open decisions
+
+*(To be populated during Phase 1.)*
+
+## Deferred to later phases
+
+*(To be populated during Phase 1.)*
+
+---
+
+*End of Tooling Specification. For decision rationale, audit notes, and revisit triggers, see the Tooling Journal.*

--- a/docs/swarm_framework.md
+++ b/docs/swarm_framework.md
@@ -1,0 +1,127 @@
+# Brainstorm Swarm Framework
+
+## Purpose
+
+A structured multi-agent ideation system for generating diverse, high-quality game design ideas for Chain Game. Agents work in parallel to prevent convergence, each seeded with a specific player persona or design domain and a reference game that shapes their mental model.
+
+---
+
+## Architecture
+
+### Phase 1 — Parallel Generation (8 agents, run simultaneously)
+
+| Agent | Type | Archetype / Domain | Reference Game | Mental Model Injected |
+|---|---|---|---|---|
+| A1 | Persona | The Optimizer | Into the Breach | Complete information + decision clarity; skilled play = seeing 2-3 moves ahead |
+| A2 | Persona | The Explorer | Baba is You | Mechanical revelation; players feel clever discovering non-obvious implications |
+| A3 | Persona | The Artist | Tetris Effect | Synesthetic identity; audio-visual response transforms a mechanical game into an emotional one |
+| A4 | Persona | The Achiever | Hades | Meta-progression psychology; failure creates narrative; runs feel distinct through emergent combinations |
+| A5 | Domain | Mechanics | Spelunky | Emergent board storytelling; fair RNG; board state encodes history |
+| A6 | Domain | Content & Rewards | Slay the Spire | Synergy as strategy; combinations > individual power; build theory from a fixed verb set |
+| A7 | Domain | Economy & Meta-Progression | Mini Metro | Network/path visual language; legible and beautiful simultaneously; constraint-driven progression |
+| A8 | Domain | Feel & Juice | Threes! | Tile personality; color as progression language; merge game with a soul |
+
+### Phase 2 — Synthesis (1 agent, runs after Phase 1 completes)
+
+Reads all 40 ideas, produces:
+- Top 10 by (novelty × pillar alignment)
+- 3 combination moves — pairs of ideas that reinforce each other
+- Constraint violations flagged
+- Cluster map — ideas that converged across multiple agents (high signal)
+
+### Optional Phase 3 — Stress Test
+
+Pick top 5 from synthesis. Spin up 5 Devil's Advocate agents, one per idea, tasked with actively breaking each idea against the six pillars. Output: survivability rating + weakest pillar for each idea.
+
+---
+
+## Quality Guardrails (enforced in every agent prompt)
+
+Every agent must, for each idea:
+
+1. **Cite a design pillar** — name which of the 6 pillars it serves and specifically how
+2. **Tag an implementation gate** — v1 / v1.5 / v2 / v2.5 / v3+ (Levels) / v4+ (Ascension) / v5+ (Drift)
+3. **Name one risk** — what could go wrong, which pillar it threatens
+4. **Produce exactly 5 ideas** — no more, no fewer
+5. **Self-rank 1–5 by novelty** — forces agents to surface their most non-obvious idea
+
+---
+
+## Hard Constraints (injected into every prompt)
+
+These are non-negotiable. Ideas that violate them are discarded:
+
+- **Rule D, k=2 is sacred** — do not propose changes to the result formula: `result = last_tile × 2 × 2^⌊s/2⌋`
+- **Core chain mechanic is fixed** — adjacency, same-value start, same-value / doubled-adjacent extensions, no tile reuse
+- **Endless mode must work standalone** — no ideas that require another mode to function
+- **Retirement is v1.5, not v1** — ideas involving retirement mechanics are tagged v1.5+
+- **No engagement-metric design** — no streak mechanics, energy systems, FOMO timers, or pay-to-continue patterns
+
+---
+
+## Design Pillars Reference
+
+From the game's design audit — all six matter equally, no tradeoffs:
+
+1. **Depth that reveals slowly** — non-obvious mechanics discovered through play, not tutorial
+2. **Interesting decisions every move** — 3–5 plausible options per turn, real tradeoffs
+3. **Failure that teaches** — loss condition is visible, concrete, skill-correlated
+4. **Felt mastery curve** — multiple skill axes, visible personal records, progress is felt
+5. **Aesthetic identity** — looks/sounds/feels like itself, not a 2048 clone *(biggest current gap)*
+6. **Honest reward structure** — results correlate with chain quality, RNG bounded by skill
+
+---
+
+## Anti-Convergence Mechanisms
+
+1. **Parallel execution** — all 8 agents run simultaneously, never see each other's output
+2. **Reference game assignment** — different mental models produce different solution spaces
+3. **Excluded concepts list** — each prompt lists 2-3 obvious ideas already on the table that agents must not repeat:
+   - *"Add a combo multiplier to the score"*
+   - *"Show a ghost/preview of the result before committing the chain"*
+   - *"Add a bomb tile that clears a 3×3 area"*
+4. **Persona vs domain split** — 4 agents think as players, 4 think as designers; these produce structurally different idea shapes
+
+---
+
+## Design Space Map
+
+Current state per area — used to orient agents:
+
+| Area | Status | Notes |
+|---|---|---|
+| Core chain mechanic | Settled | Rule D, k=2; 8-way adjacency; no tile reuse |
+| Grid | Settled (tunable) | 6×7 default; 5×6 to 7×8 range |
+| Spawn distribution | Settled (tunable) | 1/value power-law; 8-tier pool |
+| Tile retirement | Designed, not built | Hard retirement; sliding 8-tier window; stranding |
+| Aesthetic identity | **Open — biggest gap** | Zero implementation; highest priority for v2.5 |
+| Score formula | Placeholder | Max tile = score; needs replacement |
+| Special tiles / Layer 2 | Deferred | Waiting for core validation |
+| Meta-progression | Deferred | v2+ priority |
+| Levels mode | Deferred | v3+ |
+| Ascension modifiers | Deferred | v4+ |
+| Drift parameters | Deferred | v5+ |
+
+---
+
+## Running the Swarm
+
+### Via Claude Code (manual)
+
+Open 8 terminal tabs. In each, run:
+```
+claude --print "$(cat docs/swarm_prompts.md | extract_prompt A1)"
+```
+
+Or use the Agent SDK to spawn all 8 in a single script (see `tools/run_swarm.py` when built).
+
+### Output format
+
+Each agent writes a structured response. Collect all 8 into a single file, then pass to the synthesis agent prompt (A9 in `swarm_prompts.md`).
+
+### Re-running with variation
+
+To get a second pass of diverse ideas:
+- Rotate reference games (swap 2-3 of the 8)
+- Change the excluded concepts list to include the top ideas from the first run
+- Swap 1-2 persona archetypes (e.g., replace The Achiever with The Completionist or The Speedrunner)

--- a/docs/swarm_prompts.md
+++ b/docs/swarm_prompts.md
@@ -1,0 +1,309 @@
+# Brainstorm Swarm Prompts
+
+Nine prompt templates: A1–A8 (parallel generation) and A9 (synthesis). Copy each block as a standalone prompt. Do not share outputs between A1–A8 until synthesis.
+
+---
+
+## SHARED CONTEXT BLOCK
+*(Prepended to every agent prompt A1–A8. Do not alter.)*
+
+```
+## Game Summary
+
+Chain Game is a 2D number-merging puzzle game for mobile web (portrait). You build chain paths across adjacent tiles to produce results. The core mechanic:
+
+- Start a chain on two adjacent same-value tiles (8-way adjacency)
+- Extend by adding a tile that is either: same value as the current end, OR exactly double the current end
+- No tile reuse within a chain
+- Chain result: result = last_tile × 2 × 2^⌊s/2⌋  (where s = same-value extensions beyond the initial pair)
+- Result tile lands on the last chain position; all other chain tiles disappear
+- Tiles fall (gravity), then new tiles spawn at top of empty columns
+- Numbers are powers of 2: 2, 4, 8, 16, 32, 64, 128, 256, 512...
+- Board: 6×7 grid (portrait)
+- Loss: no adjacent same-value pairs exist anywhere (no legal chain start)
+- Tile retirement (v1.5): when player first reaches 512, the "2" tier retires permanently from the spawn pool; pool shifts up one tier. This repeats at each milestone. Retired tiles stay on board as orphaned blockers.
+
+## Design Pillars (all six matter equally)
+1. Depth that reveals slowly
+2. Interesting decisions every move
+3. Failure that teaches
+4. Felt mastery curve
+5. Aesthetic identity ← BIGGEST CURRENT GAP
+6. Honest reward structure
+
+## Hard Constraints — ideas violating these are invalid
+- Rule D formula is fixed: result = last_tile × 2 × 2^⌊s/2⌋
+- Core chain mechanic is fixed (adjacency rules, no tile reuse)
+- Endless mode must work standalone
+- No engagement-metric design (no energy systems, FOMO timers, streak-or-lose mechanics)
+- No pay-to-continue patterns
+
+## Already on the table — do NOT repeat these
+- Adding a combo score multiplier
+- Showing a ghost/preview of result before committing chain
+- Adding a bomb tile that clears a 3×3 area
+
+## Output format (required)
+
+For each of your 5 ideas, write:
+
+**Idea [N]: [Short title]**
+- What it is: [1-3 sentences, specific and concrete]
+- Pillar served: [name the pillar + one sentence on how]
+- Implementation gate: [v1 / v1.5 / v2 / v2.5 / v3+ / v4+ / v5+]
+- Risk: [one specific thing that could go wrong and which pillar it threatens]
+
+At the end, add:
+**My novelty ranking (most → least novel): [5 → 1]**
+```
+
+---
+
+## A1 — The Optimizer (Into the Breach)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are designing for The Optimizer — a player who wants to find the ceiling of the system. They want to beat their personal record, discover the theoretically perfect sequence, and feel like their skill has a hard limit they can approach. They read wikis, track stats, think in terms of efficiency and expected value.
+
+## Your Reference Game: Into the Breach
+
+Into the Breach gives players complete information about the board state — nothing is hidden. Every enemy intention is shown. The entire consequence tree is legible before you act. Despite this, decisions are hard and interesting. Skilled play means seeing the 2nd and 3rd order consequences of each choice clearly.
+
+Think through Into the Breach's lens: board state legibility, decision clarity, how skilled play looks different from average play on the same board, how to surface the true depth of a mechanic to a player who is actively seeking it.
+
+## Your Task
+
+Generate exactly 5 ideas that The Optimizer would love — ideas that reward mastery, make skilled play more legible, or surface strategic depth that currently requires 20+ games to discover. Ideas can span any design category (mechanics, content, UI, progression, feel).
+
+Follow the output format exactly.
+```
+
+---
+
+## A2 — The Explorer (Baba is You)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are designing for The Explorer — a player motivated by discovery. They want to find the non-obvious thing, the mechanic the game didn't tell them about, the combination that surprises them. They feel smart when the game reveals a depth they uncovered themselves. They stop playing when there's nothing left to find.
+
+## Your Reference Game: Baba is You
+
+Baba is You is built around mechanical revelation. Its rules seem simple; their implications are not. The game structures play so that players discover non-obvious consequences themselves — and feel clever doing so, not confused. The game never over-explains. Every "aha" moment is earned, not given.
+
+Think through Baba is You's lens: how to architect mechanics so non-obvious implications reveal themselves through play, how to make discovery feel earned, what the chain mechanic's undiscovered depths might be, how to reward the player who probes the system.
+
+## Your Task
+
+Generate exactly 5 ideas that The Explorer would love — ideas that create discovery moments, hide depth for players to find, or reward probing the system's edges. Ideas can span any design category.
+
+Follow the output format exactly.
+```
+
+---
+
+## A3 — The Artist (Tetris Effect)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are designing for The Artist — a player who plays games for how they feel, look, and sound. They played Threes! because it was beautiful, not because the mechanics were tight. They will stop playing a game that sounds bad. They share screenshots. They describe games using emotional language ("it felt like breathing," "it made me feel small"). The game's aesthetic identity is currently its biggest gap — this player would not pick it up yet.
+
+## Your Reference Game: Tetris Effect
+
+Tetris Effect took the most mechanical of puzzle games and transformed it into an emotional, almost spiritual experience purely through audio-visual response. Every placement generates sound. Block rows create music. The environment responds to play rhythm. The game achieves synesthesia — the mechanical and the emotional are inseparable. This proved that even a 35-year-old mechanic can feel completely new through audio-visual identity.
+
+Think through Tetris Effect's lens: what does a chain feel like to play, not just score? What does a doubling extension sound like vs a same-value extension? What does the board state look like as a visual object? What could give this game an identity that makes it feel like itself and nothing else?
+
+## Your Task
+
+Generate exactly 5 ideas focused on aesthetic identity, feel, audio, animation, or visual language. The Artist must be able to love this game. Ideas should be concrete and specific, not vague aesthetic direction.
+
+Follow the output format exactly.
+```
+
+---
+
+## A4 — The Achiever (Hades)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are designing for The Achiever — a player who needs visible progress to keep going. They want to feel like every session moved something forward, even a failed run. They collect things, complete things, hit milestones. Without a sense of accumulation, they drift away. They are not the same as an engagement-metric target — they want genuine progress, not manufactured urgency.
+
+## Your Reference Game: Hades
+
+Hades is the master class in meta-progression that feels earned rather than artificial. Every failed run advances the narrative. Boon combinations create emergent "builds" that make each run feel distinct. The Pact of Punishment lets players tune their own difficulty. Death is never wasted — something always changes. Players return not because they have to, but because each run feels like a new sentence in an ongoing story.
+
+Think through Hades's lens: how can a failed Chain Game session still feel like progress? What could accumulate across sessions? How could run-to-run variation make each attempt feel like its own story? How could the retirement mechanic, board state, or chain history become narrative material?
+
+## Your Task
+
+Generate exactly 5 ideas that give The Achiever visible, meaningful progress — across sessions, within a session, or both. Avoid artificial engagement mechanics. Ideas can span meta-progression, scoring, unlocks, narrative, or stats.
+
+Follow the output format exactly.
+```
+
+---
+
+## A5 — Mechanics Domain (Spelunky)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are a game designer focused on core mechanics — the verbs, interactions, board behaviors, and systemic rules that produce the play experience. You are not thinking about UI, progression, or aesthetics. You are thinking about what happens on the board and why it is or isn't interesting.
+
+## Your Reference Game: Spelunky
+
+Spelunky's board states tell stories. "I was doing great until the ghost spawned and I panicked." The environment is a set of interacting systems, not a backdrop — the shopkeeper, the arrow traps, the ghost timer all interact with each other and the player in emergent ways. Crucially: Spelunky's RNG feels fair because every death has a legible cause. The board encodes its own history. A great Spelunky run is a narrative.
+
+Think through Spelunky's lens: how can the Chain Game board tell a story? How can the retirement mechanic's orphaned tiles feel like dramatic characters rather than arbitrary obstacles? How can RNG produce fair-feeling variance rather than arbitrary loss? What board behaviors could interact emergently to produce surprising but legible outcomes?
+
+## Your Task
+
+Generate exactly 5 ideas in the mechanics domain — new interaction types, board behaviors, chain rule variations at the edges (not the core), tile behaviors, or systemic interactions. Stay within the hard constraints.
+
+Follow the output format exactly.
+```
+
+---
+
+## A6 — Content & Rewards Domain (Slay the Spire)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are a game designer focused on content and reward design — special tiles, objectives, power-ups, events, and the moment-to-moment reward gradient that makes players feel good about their choices.
+
+## Your Reference Game: Slay the Spire
+
+Slay the Spire's genius is synergy over individual power. A card that seems weak becomes game-defining in the right build. The game creates strategic depth not by adding complex individual mechanics but by making simple mechanics combine in non-obvious ways. Every card pick is interesting because of what it implies about your existing deck, not just its own stats. Players talk about their runs in terms of the build they discovered, not the individual cards they played.
+
+Think through Slay the Spire's lens: what chain behaviors could unlock content that synergizes with other content? Not "chain of 7 = bomb tile" (simple additive) but "what combination of tile types or chain patterns creates an emergent strategic direction?" How could Layer 2 content deepen the Climb vs Clear tradeoff rather than bypassing it?
+
+## Your Task
+
+Generate exactly 5 ideas for special tiles, triggered content, or reward patterns — things that emerge from chain behaviors (length, doublings, tier combinations, board position) and create new strategic dimensions rather than just power spikes.
+
+Follow the output format exactly.
+```
+
+---
+
+## A7 — Economy & Meta-Progression Domain (Mini Metro)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are a game designer focused on economy and meta-progression — scoring systems, currencies, unlocks, cross-session persistence, and how the player's relationship with the game deepens over time.
+
+## Your Reference Game: Mini Metro
+
+Mini Metro is a game about networks and connections — drawing paths between nodes under constraint. Its aesthetic makes the network itself beautiful and legible: the game board is a transit map, and the player's job is to make it more elegant. Progression is about managing a growing, changing network with limited resources. The game's economy is spatial and visual, not numeric — you feel the pressure of constraint rather than read it off a stat sheet.
+
+Think through Mini Metro's lens: how could Chain Game's board state feel like a network being managed rather than a grid being cleared? How could progression systems be visual and spatial rather than numeric? What would a "transit map" equivalent look like for chain paths? How could economy design make the board itself feel like an owned, evolving object?
+
+## Your Task
+
+Generate exactly 5 ideas for economy, scoring, meta-progression, or cross-session systems. Think about what accumulates, what players own, and how the relationship with the game deepens over 10, 50, and 200 sessions.
+
+Follow the output format exactly.
+```
+
+---
+
+## A8 — Feel & Juice Domain (Threes!)
+
+```
+[PASTE SHARED CONTEXT BLOCK HERE]
+
+## Your Role
+
+You are a game designer focused on game feel — animation, audio, tactile response, visual feedback, the micro-moments of delight that make a game feel alive rather than functional. You care about what happens in the 200 milliseconds after a chain completes, not just what the score says.
+
+## Your Reference Game: Threes!
+
+Threes! is the gold standard for a merge game with a soul. Each tile has a face, a mood, and a voice. Color encodes progression in a way that feels organic, not mechanical. The "whisper" audio cues create intimacy. Small tiles are chirpy; large tiles are deep. Merging feels like introduction rather than arithmetic. The game proved that aesthetic identity is not decoration on top of mechanics — it IS a mechanic, because it makes every interaction feel meaningful and distinct.
+
+Think through Threes!'s lens: what does each tier of number feel like as a character? What does a chain path look like as a visual object while it's being built? What is the audio signature of a doubling extension vs a same-value extension? What happens visually when a chain completes vs when a milestone is hit? How do you make this game feel like *itself* and nothing else?
+
+## Your Task
+
+Generate exactly 5 ideas for audio, animation, visual feedback, tile presentation, or micro-interaction design. Be specific and concrete — not "tiles should have personality" but exactly what form that personality takes and how it's communicated.
+
+Follow the output format exactly.
+```
+
+---
+
+## A9 — Synthesis Agent
+
+```
+## Your Role
+
+You are a synthesis agent. You have received 40 game design ideas from 8 agents who explored Chain Game design in parallel. Your job is not to generate new ideas but to find signal in what was produced.
+
+## Chain Game Core (brief)
+
+A 2D number-merging puzzle (mobile web). Players build chain paths across adjacent same-value tiles; extending with same-value or doubled-adjacent tiles. Result formula: last_tile × 2 × 2^⌊s/2⌋. Powers of 2 on a 6×7 grid. Tile retirement at milestones. Biggest gap: aesthetic identity.
+
+## Design Pillars
+1. Depth that reveals slowly
+2. Interesting decisions every move
+3. Failure that teaches
+4. Felt mastery curve
+5. Aesthetic identity ← biggest gap
+6. Honest reward structure
+
+## Your Task
+
+Analyze all 40 ideas and produce the following sections:
+
+---
+
+### 1. Cluster Map
+Group ideas that converged across multiple agents (same underlying concept, different surface form). List each cluster with:
+- Cluster name
+- Which agents proposed it (A1–A8)
+- Why convergence is a signal
+
+### 2. Top 10 Ideas
+Ranked by (novelty × pillar alignment). For each:
+- Idea title and originating agent
+- One sentence on why it ranks here
+- Implementation gate
+
+### 3. Outliers Worth Examining
+2–3 ideas that appeared in only one agent and are the most conceptually distinct from everything else. These are high-novelty, unvalidated.
+
+### 4. Combination Moves
+3 pairs of ideas that, combined, reinforce each other in ways neither achieves alone. For each pair:
+- Idea A + Idea B
+- Why the combination is stronger than either alone
+- Any implementation dependency between them
+
+### 5. Constraint Violations
+List any ideas that violate the hard constraints (Rule D tampering, Endless mode dependency, engagement mechanics). Flag which constraint and why.
+
+### 6. Aesthetic Identity Shortlist
+Pull out every idea that addresses the aesthetic identity gap specifically. Rank them 1–N by how directly and concretely they address it.
+
+---
+
+[PASTE ALL 40 IDEAS FROM AGENTS A1–A8 HERE]
+```

--- a/docs/swarm_results.md
+++ b/docs/swarm_results.md
@@ -1,0 +1,425 @@
+# Brainstorm Swarm Results
+
+*8 agents run in parallel (A1–A8), followed by synthesis (A9). 2026-04-28.*
+
+---
+
+## SYNTHESIS (A9)
+
+---
+
+### 1. Cluster Map
+
+**Cluster A: "Resonance" / Hidden Tile State**
+Agents: A1 (Orphan Pressure Map), A2 (Resonance Chains), A5 (Resonance Chains Fork), A6 (Resonance Tiles)
+The word "resonance" appears independently in A2, A5, and A6 with different mechanics but the same underlying idea: tiles accumulate hidden state through board activity that modifies chain results. A1's Orphan Pressure Map is the information-only cousin. **Convergence signal:** four agents from different design lenses reached for the same concept (tiles with memory) as the primary depth lever. This is the strongest convergence in the set.
+
+**Cluster B: "Echo" / Chain History as Persistent Visual Layer**
+Agents: A2 (Chain Echo), A3 (Echo Trails), A5 (Echo Tiles), A6 (Echo Chains), A7 (Route Memory)
+Five agents independently proposed some form of chain-path persistence — either mechanical (A2, A5, A6) or purely visual (A3, A7). The mechanical versions diverge significantly (compounding s-value vs. double-on-use vs. echo window), but the visual ones (A3 trails, A7 transit lines) are nearly identical. **Convergence signal:** chain history as a readable artifact is the single most cross-agent idea in the set. The game currently discards all path information on resolve — agents across every domain flagged this as a loss.
+
+**Cluster C: "Fault Lines" / Named Board Hazard**
+Agents: A2 (Fault Lines), A5 (Fault Lines), A6 (Fault Lines)
+Three agents proposed "fault lines" by name. A2's version is invisible and shifts; A5's creates hanging tiles; A6's creates cracked tiles that cascade. All three share: a persistent board feature dividing the grid that creates routing decisions. **Convergence signal:** agents independently sensed the 6×7 board is too uniform — it needs structural asymmetry beyond tile values. The fault line concept is the dominant answer.
+
+**Cluster D: Retirement Legibility / Milestone Ceremony**
+Agents: A1 (Retirement Countdown), A4 (Retirement Ledger), A7 (Tile Retirement Ledger)
+Three agents — from Into the Breach, Hades, and Mini Metro lenses — proposed making retirement milestones legible and ceremonial. A1 focuses on countdown-to-event; A4 and A7 both propose a persistent ledger. **Convergence signal:** retirement is a designed milestone that currently lands as a surprise. Agents across optimizer, achiever, and meta-progression lenses all flagged the same gap.
+
+**Cluster E: Audio-Visual Tile Identity**
+Agents: A3 (Harmonic Audio Synthesis), A8 (Tier Voice Registers)
+Two agents independently proposed assigning musical pitches to tile values on a harmonic scale, with chain-building producing real-time melodic phrases. The implementations are nearly identical. **Convergence signal:** the strongest single aesthetic identity proposal appears independently from two different agents. High implementation confidence.
+
+**Cluster F: Chain Path as Physical/Visual Object**
+Agents: A3 (Echo Trails), A7 (Route Memory), A8 (Chain Path Ink Trail)
+Three agents proposed giving the chain path material presence beyond a selection highlight. **Convergence signal:** the current chain path is experienced as temporary and weightless. Agents from artist, economy, and feel lenses all independently reached for "make the path a thing."
+
+---
+
+### 2. Top 10 Ideas
+
+Ranked by (novelty × pillar alignment), with extra weight on aesthetic identity (biggest current gap).
+
+**#1 — Chain Path Ink Trail (A8)** | Gate: v1.5
+The chain path renders as an animated ink stroke with material properties: thickness, ink-bleed, hue-ramp by result value, contraction on commit, cracking on abandon. Directly addresses aesthetic identity with a concrete visual language that encodes mechanical information (chain value) in the material itself. Making the act of building a chain feel like drawing.
+
+**#2 — Harmonic Audio Synthesis / Tier Voice Registers (A3 + A8 — convergent)** | Gate: v2
+Tile values map to instrument tiers on a pentatonic scale; chain-building composes a live melodic phrase; completion plays a chord bloom. Most validated aesthetic identity proposal in the set (two independent arrivals). Addresses two pillars simultaneously: aesthetic identity and felt mastery (players recognize tile values by ear before reading the number).
+
+**#3 — Breath Board (A3)** | Gate: v1.5
+The board animates with idle breathing: tiles pulse at phase-offset rates, higher-value tiles pulse slower, a haze drifts between high-value neighbors. Touch snaps everything to stillness; release exhales. The only idea addressing the board's feel between moves — the ~80% of elapsed time when the player is planning.
+
+**#4 — Tile Face Aging (A8)** | Gate: v2
+Tiles carry two-dot eyes expressing lifecycle: wide-open (fresh), heavy-lidded (3+ turns old), closed (orphaned/retired). Eyes track drag direction during chain-building; result tile blinks open on creation. Most conceptually distinct aesthetic identity proposal — tiles become characters with felt lifecycles. The orphan state is load-bearing: closed eyes makes retirement inertness immediately readable without a UI label.
+
+**#5 — Color Temperature Gradient (A3)** | Gate: v1.5
+Tile color follows a designed thermal gradient: deep ocean blue-teal (low values) → amber-gold (mid) → white-violet (high). Retired tiles render desaturated grey. Board average color temperature shifts as player progresses — early game cold, late game burning. Solves aesthetic identity at the foundational level; all other visual ideas build on a strong color base.
+
+**#6 — Retirement Countdown (A1)** | Gate: v1.5
+A numeric counter on the current-lowest tier tiles showing estimated spawns before next retirement. Transforms retirement from a surprise event into a planning horizon — the optimizer starts stockpiling higher-tier pairs before the tier disappears. Convergent with A4 and A7 (Cluster D), validating the gap.
+
+**#7 — Orphan Cascade (A5)** | Gate: v1.5
+Retired orphan tiles gain a lifecycle: placed → cracked (sandwiched by chain tiles) → wild for one chain → shattered. Orphans become ticking dramatic resources rather than inert blockers. The only idea making the retirement mechanic's byproduct exciting rather than depressing.
+
+**#8 — Chain Commit Freeze Frame (A8)** | Gate: v1
+At chain commit, 120ms freeze: path flashes white, result value appears large. Then tiles vanish along path in sequence (30ms/tile, particle burst per tier color). Result tile materializes last (~400ms total). Simplest implementation in the top 10, improves every session regardless of skill level, directly addresses "failure that teaches."
+
+**#9 — Epitaphs (A4)** | Gate: v1.5
+Run-end generates a one-line epitaph from actual run data ("Held the board together for 43 moves. Never touched a 256."). Saved to a scrollable graveyard. Reframes loss as a completed story and accumulates into a personal record. Highest-novelty "failure that teaches" entry.
+
+**#10 — Gravity Scar (A5)** | Gate: v2
+Chains of length 6+ mark their result column as a scar for 3 turns; scarred columns spawn tiles one tier higher. Scars are visible. Long chains in a column accelerate local inflation — double-edged reward that makes column choice carry medium-term consequence. Most targeted at "interesting decisions every move" through spatial commitment.
+
+---
+
+### 3. Outliers Worth Examining
+
+**Adjacency Shadow (A2)**
+Each tile has a hidden directional "shadow" based on spawn origin (column-gravity vs. chain-result placement). Aligned-shadow chain starts double the result. The axis is readable only from a 1-pixel gradient on the tile edge. The only idea in the set where visual language is mechanically load-bearing — reading the art correctly gives a gameplay advantage. Direct implementation of the Baba Is You principle ("visual grammar encodes rule grammar"). Has no analogue in any other agent's output. The 1-pixel risk is an implementation constraint, not a design flaw — a slightly larger indicator could preserve "hidden in plain sight" quality. High novelty, unvalidated, worth a prototype.
+
+**Inheritance System (A4)**
+At run end, the player chooses one inheritance: a single tile (their run's highest value, capped) placed at a fixed board position at the next run's start. Visually distinct. No other agent proposed any form of cross-run mechanical persistence. Structurally different from meta-progression (not a permanent upgrade) and from roguelike boons (it's your own achievement, not a random gift). Creates genuine run-to-run continuity without power escalation; makes the end-of-run moment matter. The risk (trivializing early tension) is manageable with placement constraints (e.g., always spawns top row, center).
+
+**Network Map (A7)**
+Between sessions, a persistent "system map" shows lifetime play as a growing transit network — each session adds a station dot connected by a line whose color and thickness encodes that session's score. After 50 sessions, the player has a dense personal map. The only idea addressing the multi-month player relationship rather than the single session. An identity object: the player's game becomes a map uniquely theirs. No other agent reached for this. Conceptually distinct from all 39 other ideas.
+
+---
+
+### 4. Combination Moves
+
+**Move 1: Color Temperature Gradient (A3) + Chain Path Ink Trail (A8)**
+The ink trail's hue ramp (low=amber, mid=rose, high=violet) is currently defined independently of the board's color system. If Color Temperature Gradient is the foundational system, the ink trail's hue ramp should *derive* from it — the chain path's color is literally made from the tiles it consumed. A long high-value chain leaves a white-violet scar against a warm board. A low-value chain leaves an amber scratch. The board's color field and the chain's color language become one unified system. Neither achieves this unification alone.
+*Dependency: Color Temperature must be specified first; Ink Trail's palette derives from it.*
+
+**Move 2: Harmonic Audio Synthesis + Chain Commit Freeze Frame (A8)**
+The freeze frame has particle bursts in tier colors during the tile-vanish sequence. If each vanishing tile also plays its note during the sequence (not during drag, but during resolve), the chain "replays" as a melodic phrase at the commit moment — the player hears the chain they built in the order they built it, while watching tiles disappear in that order. The freeze frame is bearable at 400ms when it is also a satisfying sound event; the audio becomes diegetically justified rather than decorative.
+*Dependency: none — both are additive; the resolve-sequence timing in Freeze Frame provides natural sync points for the audio.*
+
+**Move 3: Retirement Countdown (A1) + Orphan Cascade (A5)**
+Retirement Countdown makes approaching tile retirement a planning horizon. Orphan Cascade makes the byproduct of retirement (orphan blockers) into a dramatic resource. These close a loop: the countdown tells you retirement is coming, so you plan; retirement fires and orphans appear; Cascade tells you orphans are not just losses — they are cracked wilds waiting to be used. Without the countdown, orphan exploitation is reactive. Without the cascade, the countdown creates dread with no productive outlet. Together they convert retirement from a surprise loss into a managed transition with strategic depth on both sides of the milestone.
+*Dependency: both require v1.5 retirement system; Countdown should ship first.*
+
+---
+
+### 5. Constraint Violations
+
+**Resonance Chains Fork (A5, Idea 2)** — *Rule D / one-chain-per-turn violation*
+Describes two separate chains resolving in the same turn via a "fork." Current rules allow one chain per turn. This requires either modifying Rule D or adding a parallel-chain mechanic. Flagged pending clarification on whether fork resolves under the existing formula.
+
+**Chain Echo (A2, Idea 2)** — *Rule D tampering*
+"The echo length adds to the new chain's s-value before calculation begins — compounding across generations." Injecting inherited s-values from prior chains into the s variable modifies how the formula is applied. The s-value is meant to represent the current chain's length, not an accumulated cross-turn value. Rule D tamper confirmed.
+
+**Line Gauge / Extension Token (A7, Idea 2)** — *Adjacency constraint violation*
+"Tokens let the player add one free tile to any legal chain mid-draw." Adding a free tile mid-chain need not be adjacent, violating the core adjacency rule. Flagged.
+
+**Tier Bridges (A6, Idea 5)** — *Rule D tampering*
+"A bridge tile counts as matching with the tier below its actual value." This means a tile can extend to a tile with half its value — the reverse of the doubling direction. Inverts the chain extension rule. Flagged.
+
+---
+
+### 6. Aesthetic Identity Shortlist
+
+Ranked by how directly and concretely each idea gives this game a recognizable identity it currently lacks:
+
+| Rank | Idea | Agent | Why |
+|---|---|---|---|
+| 1 | Color Temperature Gradient | A3 | Operates at the foundation — the color system for all tiles, all sessions, all screenshots |
+| 2 | Chain Path Ink Trail | A8 | Transforms the primary interaction into a drawing act — the interaction identity |
+| 3 | Harmonic Audio Synthesis / Tier Voice Registers | A3/A8 | Only idea addressing identity in a non-visual channel — the audio complement to Color Temperature |
+| 4 | Tile Face Aging | A8 | Most emotionally distinctive — tiles are alive, aging, dying. No other merge puzzle does this |
+| 5 | Breath Board | A3 | Covers the 80% of session time that no other idea touches — planning-phase identity |
+| 6 | Echo Trails | A3 | Board-as-palimpsest — session history made visible. Complements Ink Trail (live gesture vs. record) |
+| 7 | Adjacency Shadow | A2 | Only idea where visual language is mechanically load-bearing — the art IS the rule |
+| 8 | Liquid Merge | A3 | Strong physical metaphor (merge = gravity) but expensive to implement on mobile |
+
+---
+
+## RAW AGENT OUTPUTS
+
+---
+
+### A1 — The Optimizer (Into the Breach)
+
+**Idea 1: Chain Forecast Overlay**
+- What it is: A toggleable HUD layer that highlights, for every legal chain start on the board, the maximum achievable result given optimal extension — displayed as a color-coded heat map directly on the tiles. Tapping a tile shows the specific path that achieves the ceiling.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2
+- Risk: Removes discovery phase for new players if not gated.
+
+**Idea 2: Efficiency Rating Per Chain**
+- What it is: After each chain resolves, display tiles consumed vs. result produced as a ratio (e.g., "4 tiles → 128 | 32/tile"). Track session-wide efficiency average. No score bonus — pure information.
+- Pillar served: Felt mastery curve
+- Implementation gate: v1.5
+- Risk: Short 2-tile chains with double extension produce misleading "high efficiency" numbers.
+
+**Idea 3: Orphan Pressure Map**
+- What it is: Column-danger indicators — a thin bar at each column bottom that fills as orphan density increases. Purely a legibility tool.
+- Pillar served: Interesting decisions every move
+- Implementation gate: v1.5
+- Risk: Adds visual noise to an already information-dense board.
+
+**Idea 4: Theoretical Maximum Tracker**
+- What it is: A persistent "Board Ceiling" stat computed each turn as the sum of maximum achievable results across all non-overlapping optimal chains on the current board. Updates in real time.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2.5
+- Risk: If the approximation is visibly wrong, it destroys trust.
+
+**Idea 5: Retirement Countdown**
+- What it is: A numeric counter on every tile of the current-lowest active tier showing estimated spawns before next retirement.
+- Pillar served: Interesting decisions every move
+- Implementation gate: v1.5
+- Risk: Estimate misfires feel like broken promises.
+
+*Novelty ranking: 4 → 3 → 5 → 1 → 2*
+
+---
+
+### A2 — The Explorer (Baba is You)
+
+**Idea 1: Resonance Chains**
+- What it is: Tiles carry a hidden resonance counter that increments each time they survive a chain without being consumed. When a tile with resonance ≥ 3 is used as a chain endpoint, the result gains an extra ×2 multiplier. Board subtly pulses the tile brighter each time.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2
+- Risk: Tiles may merge or fall before resonance accumulates, making mechanic invisible.
+
+**Idea 2: Chain Echo**
+- What it is: After a chain resolves, the result tile remembers its chain length. If that tile later starts a new chain, the echo length adds to the new chain's s-value. A faint ring animation is the only hint.
+- Pillar served: Interesting decisions every move
+- Implementation gate: v2.5
+- Risk: Compounding multipliers could break score scaling. *[FLAGGED: Rule D tamper — see Constraint Violations]*
+
+**Idea 3: Fault Lines**
+- What it is: Invisible column-pair fault lines that shift position every ~15 moves. When a chain crosses a fault line, one extra tile is consumed but not counted in s — silently disappears.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v3+
+- Risk: Silent tile loss may read as a bug rather than a mechanic.
+
+**Idea 4: Value Memory (Orphan Inheritance)**
+- What it is: When a retired orphan blocker is consumed in a chain, the result tile inherits the orphan's original tier value as a hidden bonus added to s.
+- Pillar served: Felt mastery curve
+- Implementation gate: v2
+- Risk: May trivialize the retirement system if exploiting orphans is always correct.
+
+**Idea 5: Adjacency Shadow**
+- What it is: Each tile has a hidden directional "shadow" based on how it spawned. Aligned-shadow chain starts double the result. Readable only from a subtle 1-pixel gradient on the tile edge.
+- Pillar served: Aesthetic identity + Depth that reveals slowly
+- Implementation gate: v3+
+- Risk: 1-pixel gradient invisible on low-DPI mobile screens.
+
+*Novelty ranking: 5 → 3 → 1 → 4 → 2*
+
+---
+
+### A3 — The Artist (Tetris Effect)
+
+**Idea 1: Harmonic Audio Synthesis Per Chain**
+- What it is: Each tile value maps to a fixed musical pitch on a pentatonic stack (2=low bass, 4=minor third, 8=fifth, 16=octave, etc.). Dragging a chain plays each tile's note in sequence. Same-value extension repeats with shimmer. Doubling extension jumps an octave. Chain completion plays the full phrase as a chord bloom.
+- Pillar served: Aesthetic identity
+- Implementation gate: v2
+- Risk: Cacophony on fast play or large boards.
+
+**Idea 2: Liquid Merge**
+- What it is: Tiles are colored liquid in glass containers. Chain draw shows liquid flowing between cells like water through pipes. On completion, all liquid rushes into the final cell, which swells and settles as the result tile.
+- Pillar served: Aesthetic identity
+- Implementation gate: v2.5
+- Risk: Fluid simulation expensive on low-end mobile; animation cannot block fast play.
+
+**Idea 3: Breath Board**
+- What it is: Board animates with idle breathing — tiles pulse at phase-offset rates, higher-value tiles pulse slower. Touch snaps everything to stillness. Chain release exhales: tiles scatter as particle dust, result tile lands with ripple propagating outward.
+- Pillar served: Aesthetic identity
+- Implementation gate: v1.5
+- Risk: Ambient animation may distract during planning.
+
+**Idea 4: Color Temperature Gradient**
+- What it is: Tile color maps to a thermal gradient: deep ocean blue-teal (2, 4) → amber/gold (16–64) → white-violet (256+). Retired tiles render desaturated grey. Board average color temperature shifts visibly with progression.
+- Pillar served: Aesthetic identity
+- Implementation gate: v1.5
+- Risk: Color accessibility; needs secondary shape/size signal for colorblind players.
+
+**Idea 5: Echo Trails**
+- What it is: Every completed chain leaves a luminous trail that fades over 3–5 seconds in the result tile's color. Multiple echoes coexist, layering. Sound design mirrors: soft tonal hum persists and fades with the trail.
+- Pillar served: Aesthetic identity
+- Implementation gate: v1.5
+- Risk: Dense fast play may obscure tile values with overlapping trails.
+
+*Novelty ranking: 5 → 3 → 1 → 2 → 4*
+
+---
+
+### A4 — The Achiever (Hades)
+
+**Idea 1: The Chain Atlas**
+- What it is: A persistent visual map recording every distinct chain shape the player has ever completed — length, path geometry, result value. Fills like a field guide; rare long chains marked as discoveries.
+- Pillar served: Felt mastery curve
+- Implementation gate: v2
+- Risk: Cluttered UI causes players to ignore it.
+
+**Idea 2: Epitaphs**
+- What it is: Run-end generates a one-line epitaph from actual run data ("Held the board together for 43 moves. Never touched a 256."). Saved to a personal graveyard.
+- Pillar served: Failure that teaches
+- Implementation gate: v1.5
+- Risk: Template staleness breaks the illusion on repeated phrasing.
+
+**Idea 3: Retirement Ledger**
+- What it is: Persistent document recording every retired tier, the run it happened on, and the highest chain produced using that tier before it left. ("Run 17: the 2s are gone. Best chain they ever produced: 128.")
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v1.5
+- Risk: Empty ledger if player never reaches retirement milestones.
+
+**Idea 4: Personal Bests by Board State**
+- What it is: Tracks personal bests segmented by active tile pool at the time — e.g., "Best score when 2s were still live: 4,820." Displayed at run-end as context for the score.
+- Pillar served: Honest reward structure
+- Implementation gate: v2
+- Risk: Too many segments fragment the sense of accomplishment.
+
+**Idea 5: The Inheritance System**
+- What it is: At run end, player chooses one "inheritance" to carry forward — a single tile (highest value achieved, capped) placed at a fixed board position at the next run's start. Visually distinct.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2.5
+- Risk: High-value inheritance could trivialize early-game tension.
+
+*Novelty ranking: 5 → 2 → 1 → 3 → 4*
+
+---
+
+### A5 — Mechanics Domain (Spelunky)
+
+**Idea 1: Orphan Cascade**
+- What it is: When a retired orphan tile is sandwiched between two chain tiles during resolve, it "cracks" — becoming a wild tile that counts as any value for one chain. After use, it shatters and disappears permanently.
+- Pillar served: Aesthetic identity (orphans have a lifecycle that encodes board history)
+- Implementation gate: v1.5
+- Risk: Wild-tile power too strong, trivializing chain-extension decisions.
+
+**Idea 2: Resonance Chains (Fork)**
+- What it is: A fork interaction where a chain passes through a tile that is simultaneously the end of another player-drawn chain. If both results are equal, they auto-merge without a chain required.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2.5
+- Risk: Fork detection complex; player may not understand why it fired. *[FLAGGED: Rule D / one-chain-per-turn — see Constraint Violations]*
+
+**Idea 3: Gravity Scar**
+- What it is: Chains of length 6+ mark their result column as a scar for 3 turns. Scarred columns spawn tiles one tier higher than the current pool.
+- Pillar served: Interesting decisions every move
+- Implementation gate: v2
+- Risk: Scar + retirement may inflate board tier faster than intended.
+
+**Idea 4: Echo Tiles**
+- What it is: Roughly every 40 spawns, one tile spawns as an Echo — same value, ghost outline. Cannot start a chain but can be a chain extension. When consumed mid-chain (not end-chain), doubles the result.
+- Pillar served: Felt mastery curve
+- Implementation gate: v1.5
+- Risk: Cannot-start rule may create apparent-but-illegal chain starts on sparse boards.
+
+**Idea 5: Fault Lines**
+- What it is: One randomly placed horizontal fault line per game session (fixed, shown at start). Tiles falling through hang for one turn mid-column. A hanging tile is adjacent to the tile above AND below simultaneously, for that turn only.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2
+- Risk: One-turn timing window may be too tight to act on deliberately on mobile.
+
+*Novelty ranking: 5 → 3 → 1 → 4 → 2*
+
+---
+
+### A6 — Content & Rewards Domain (Slay the Spire)
+
+**Idea 1: Resonance Tiles**
+- What it is: Special tile that mirrors the chain's current end value when included. Acts as a same-value extension. If chain ends ON the resonance tile, it locks as that value and splits into two tiles of that value on the nearest empty adjacent cells.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2
+- Risk: Mirroring rule confuses new players about the tile's value during building.
+
+**Idea 2: Fault Lines**
+- What it is: Column boundaries periodically marked as fault lines. When a chain result lands, tiles on both sides of a fault line at the same row gain a hairline crack. A cracked tile used as same-value extension in any future chain causes a cascade clear of all cracked tiles on board.
+- Pillar served: Interesting decisions every move
+- Implementation gate: v2.5
+- Risk: Too-frequent fault lines fill board with cracks, becoming noise.
+
+**Idea 3: Echo Chains**
+- What it is: After any chain with ≥2 doubling steps, an "echo window" opens for one move. The first chain starting on the result tile gets its final result doubled. Echo window expires after any other chain or timer.
+- Pillar served: Felt mastery curve
+- Implementation gate: v1.5
+- Risk: Timer edges toward FOMO; must be generous.
+
+**Idea 4: Anchor Tiles**
+- What it is: Rare tiles marked with anchor icon that cannot be moved by gravity. Can only be removed by ending a chain directly on them. Terminal anchor multiplies chain result by 1.5× rounded up to nearest power of 2. Spawn only in bottom two rows. One anchor max at a time.
+- Pillar served: Interesting decisions every move
+- Implementation gate: v2
+- Risk: Multiple simultaneous anchors create unwinnable states (must cap at one).
+
+**Idea 5: Tier Bridges**
+- What it is: Chain touching exactly three distinct value tiers produces a "bridge" result tile, which counts as matching with both the tier below and above for chain-start purposes, for one use only.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2.5
+- Risk: Three-tier chain trigger is non-obvious; players may never discover it. *[FLAGGED: Rule D tamper — see Constraint Violations]*
+
+*Novelty ranking: 4 → 1 → 5 → 3 → 2*
+
+---
+
+### A7 — Economy & Meta-Progression Domain (Mini Metro)
+
+**Idea 1: Route Memory**
+- What it is: Board remembers last 3 completed chains as faint colored transit-line overlays. Non-mechanical, purely visual. Board accumulates a palimpsest of decision history over a session.
+- Pillar served: Aesthetic identity
+- Implementation gate: v2
+- Risk: Visual clutter obscures tile readability.
+
+**Idea 2: Line Gauge (Session Economy)**
+- What it is: Chains contribute length-points to a Line Gauge progress bar styled as an extending transit route at the screen edge. Full gauge banks one Extension Token. Tokens let player add one free tile to any legal chain mid-draw. Max 3 tokens carry into next session.
+- Pillar served: Depth that reveals slowly
+- Implementation gate: v2.5
+- Risk: Free-tile bridge trivializes adjacency constraint at high token income. *[FLAGGED: Adjacency constraint violation — see Constraint Violations]*
+
+**Idea 3: Network Map (Cross-Session Meta)**
+- What it is: Persistent "system map" screen between sessions — each session adds a station dot connected by a line whose color and thickness encodes that session's score. Milestone unlocks add named stations. After 50 sessions: a dense personal map.
+- Pillar served: Felt mastery curve
+- Implementation gate: v3+
+- Risk: Sparse map for infrequent players may feel punishing.
+
+**Idea 4: Tile Retirement Ledger**
+- What it is: Persistent sidebar styled as grayed-out transit lines taken out of service, one per retired tier, with the session number it retired in.
+- Pillar served: Honest reward structure
+- Implementation gate: v1.5
+- Risk: Empty ledger for players who never reach retirement.
+
+**Idea 5: Demand Pulse (Board Pressure Economy)**
+- What it is: Every 8 moves, one random column pulses as a high-demand corridor. Chains terminating in that column this turn score 2× result. Pulse travels to adjacent column each trigger, circling the board.
+- Pillar served: Interesting decisions every move
+- Implementation gate: v2
+- Risk: Multiplier interacting with Rule D may feel arbitrary.
+
+*Novelty ranking: 5 → 3 → 1 → 2 → 4*
+
+---
+
+### A8 — Feel & Juice Domain (Threes!)
+
+**Idea 1: Tier Voice Registers**
+- What it is: Each tier has a distinct instrument family: 2=thumb-piano plucks, 4=marimba, 8=vibraphone, 16=steel-string guitar harmonics, 32=cello pizzicato, 64=bowed bass, 128+=synth-organ with sub-bass. Tapping a tile plays its note. Each extension plays the next tile's note, building a melodic phrase. Chain completion plays all notes as a chord.
+- Pillar served: Aesthetic identity
+- Implementation gate: v2
+- Risk: Melodic randomness could feel cacophonous on dissonant tile layouts.
+
+**Idea 2: Chain Path Ink Trail**
+- What it is: Chain path renders as an animated ink stroke — thick, slightly irregular, with ink-bleed at tile nodes. Stroke color shifts along a warm hue ramp by result value (low=amber, mid=rose, high=violet). On commit, ink contracts inward to result tile as a reverse brushstroke; result tile absorbs it with an ink-bloom pulse. Abandoned chains: ink dries out, cracks, fades.
+- Pillar served: Aesthetic identity
+- Implementation gate: v1.5
+- Risk: Canvas rendering of dynamic ink strokes may drop frames on mobile during drag.
+
+**Idea 3: Tile Weight Physics on Drop**
+- What it is: Drop animations weighted by tile value: 2s/4s fall with quick light bounce; 32s/64s fall with heavy thud and slight screen-shake; 128+ briefly compresses all tiles in column by 4px before spring-back. Result tile always lands with the heaviest animation. Sound: wooden tap (small) → felt thud (mid) → stone impact (large).
+- Pillar served: Felt mastery curve
+- Implementation gate: v1.5
+- Risk: Column compression could create visual confusion about board state.
+
+**Idea 4: Tile Face Aging**
+- What it is: Tiles have minimal two-dot eyes. Fresh = wide-open. 3+ turns without use = heavy-lidded. Orphaned retired tiles = closed eyes, slightly faded fill. Selected tile's eyes open wide and pupils track drag direction. Result tile blinks open on creation.
+- Pillar served: Aesthetic identity
+- Implementation gate: v2
+- Risk: Face rendering adds per-tile complexity; aging state may be missed as decorative noise.
+
+**Idea 5: Chain Commit Freeze Frame**
+- What it is: At chain commit (finger release), 120ms freeze: all tiles freeze, path flashes white, result value appears large over resolution zone. Then tiles vanish in sequence from first to last (30ms/tile, particle burst in tier color). Result tile slides in from above the board edge. Total ~400ms.
+- Pillar served: Failure that teaches
+- Implementation gate: v1
+- Risk: 400ms per chain resolution compounds into sluggishness under fast play.
+
+*Novelty ranking: 4 → 2 → 1 → 5 → 3*


### PR DESCRIPTION
## Summary
- Adds 5 game design docs (spec, journals, concepts) to `docs/`
- `swarm_framework.md`: complete 8-agent parallel swarm design — personas, domains, reference games, anti-convergence mechanisms, quality guardrails
- `swarm_prompts.md`: 9 copy-paste prompt templates ready to run (A1–A8 generation + A9 synthesis)

## Reference games assigned
| Agent | Archetype/Domain | Game |
|---|---|---|
| A1 | Optimizer | Into the Breach |
| A2 | Explorer | Baba is You |
| A3 | Artist | Tetris Effect |
| A4 | Achiever | Hades |
| A5 | Mechanics | Spelunky |
| A6 | Content & Rewards | Slay the Spire |
| A7 | Economy & Meta | Mini Metro |
| A8 | Feel & Juice | Threes! |

## Test plan
- [ ] Review `swarm_framework.md` for completeness
- [ ] Copy an agent prompt from `swarm_prompts.md`, paste into Claude, verify it produces valid structured output
- [ ] Run all 8 in parallel, collect output, run A9 synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)