### PR TITLE
[codex] Implement Phase 4 retirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+.claude/
+coverage/

--- a/docs/engineering/RETIREMENT_DESIGN_NOTES.md
+++ b/docs/engineering/RETIREMENT_DESIGN_NOTES.md
@@ -1,0 +1,72 @@
+# Retirement Design Notes
+
+**Status:** Phase 4 working notes  
+**Owner:** Engineering, for Evan review  
+**Created:** 2026-04-28
+
+## Validation Item: Overshoot Retirement Pacing
+
+Phase 4 currently experiments with **cascade retirement within a committed chain**.
+The spawn pool remains an 8-tier sliding window, so it does **not** grow wider:
+
+| Retirement count | Active spawn pool |
+|---|---|
+| 0 | 2-256 |
+| 1 | 4-512 |
+| 2 | 8-1024 |
+| 3 | 16-2048 |
+
+The edge case to test is a chain result that jumps over more than one retirement threshold.
+Example: active pool is `2-256`, and the player creates `2048` in one chain.
+
+Current behavior:
+- Same turn: `2`, `4`, and `8` retire in order.
+- Pool becomes `16-2048`.
+- The pool width stays fixed at 8 tiers, and the active ceiling catches up immediately to `maxTileEver`.
+
+Alternative behavior:
+- Cap retirement at one tier per committed chain.
+- Example above would retire only `2`; pool becomes `4-512`.
+- Later turns would retire additional tiers one at a time until the pool catches up.
+
+## Implications to Playtest
+
+One-retirement-per-turn is gentler and keeps milestone pressure paced, but it can create delayed retirement pressure: a later small chain may trigger a retirement caused by an earlier large overshoot. It also gives players extra cleanup time for soon-to-retire tiers.
+
+Cascade retirement is more internally synchronized with player achievement, but it may feel punishing if one strong chain suddenly strands multiple tiers.
+
+## Proposed Gate Check
+
+During Phase 4 UAT, deliberately create or simulate at least one threshold overshoot and decide whether:
+
+1. cascade retirement feels readable and fair, or
+2. retirement should be capped at one tier per committed chain.
+
+The current implementation emits one `retirement-fired` event per retired tier in the same transition.
+
+## Phase 5 Simulation Follow-Up
+
+Retirement pacing should be tested manually in Phase 4, then measured statistically in Phase 5 once the Simulation Harness exists.
+
+The Phase 5 sim schema should include retirement-specific metrics before runner implementation begins:
+
+- turn of first retirement
+- turn of each retirement milestone
+- number of retirement events per game
+- number of cascade retirements per transition
+- whether a cascade retirement is followed by immediate `game-over`
+- max tile reached before death
+- active spawn pool at death
+- retired tile count on board over time
+- isolated retired tile count on board over time
+- legal chain-start count before and after each retirement
+- chain length and result value that triggered each retirement
+
+These metrics should be compared across at least:
+
+- cascade retirement vs one-retirement-per-turn
+- different `ruleK` values
+- different spawn weight profiles
+- different automated strategies
+
+Goal: determine whether retirement adds strategic depth without creating an unfair difficulty cliff, and whether cascade retirement creates better pacing than delayed one-step retirement.

--- a/src/game-kernel/board.ts
+++ b/src/game-kernel/board.ts
@@ -90,7 +90,11 @@ function pickTileValue(
   let v = config.spawnPoolMin;
   while (v <= config.spawnPoolMax) {
     /* v8 ignore next 1 */
-    const weight = config.spawnWeights[v] ?? 0;
+    const configuredWeight = config.spawnWeights[v];
+    const previousTier = (v / 2) as TileValue;
+    const weight = configuredWeight ?? (
+      v === config.spawnPoolMax ? (config.spawnWeights[previousTier] ?? 1) / 2 : 0
+    );
     if (weight > 0) {
       entries.push([v, weight]);
       totalWeight += weight;

--- a/src/game-kernel/index.ts
+++ b/src/game-kernel/index.ts
@@ -11,10 +11,12 @@ import type {
   GameEvent,
   ChainResolvedEvent,
   TilesSpawnedEvent,
+  RetirementFiredEvent,
   GameOverEvent,
 } from './types.js';
 import { applyGravity, setTile, removeTiles, spawnTiles } from './board.js';
 import { getAdjacentCells, validateChainExtension, resolveChain } from './chain.js';
+import { checkRetirement, advanceSpawnPool, markRetiredTiles } from './retirement.js';
 
 // Re-export public types
 export type {
@@ -62,7 +64,11 @@ function pickTileValue(
 
   let v = config.spawnPoolMin;
   while (v <= config.spawnPoolMax) {
-    const weight = config.spawnWeights[v] ?? 0;
+    const configuredWeight = config.spawnWeights[v];
+    const previousTier = (v / 2) as TileValue;
+    const weight = configuredWeight ?? (
+      v === config.spawnPoolMax ? (config.spawnWeights[previousTier] ?? 1) / 2 : 0
+    );
     if (weight > 0) {
       entries.push([v, weight]);
       totalWeight += weight;
@@ -319,15 +325,6 @@ export function applyAction(state: GameState, action: Action): GameState {
       // Apply gravity
       board = applyGravity(board);
 
-      // Spawn L-1 tiles
-      const { board: boardAfterSpawn, prngState: newPrng, spawned } = spawnTiles(
-        board,
-        chain.length,
-        state.config,
-        state.prngState
-      );
-      board = boardAfterSpawn;
-
       // Build chain-resolved event
       const chainResolvedEvent: ChainResolvedEvent = {
         kind: 'chain-resolved',
@@ -339,6 +336,47 @@ export function applyAction(state: GameState, action: Action): GameState {
       };
       newEvents.push(chainResolvedEvent);
 
+      // Update maxTileEver
+      const newMaxTileEver = (
+        resultValue > state.maxTileEver ? resultValue : state.maxTileEver
+      );
+
+      let runtimeSpawnConfig: GameConfig = {
+        ...state.config,
+        spawnPoolMin: state.spawnPoolMin,
+        spawnPoolMax: state.spawnPoolMax,
+      };
+      let newSpawnPoolMin = state.spawnPoolMin;
+      let newSpawnPoolMax = state.spawnPoolMax;
+
+      for (;;) {
+        const retiredTier = checkRetirement(newMaxTileEver, newSpawnPoolMax);
+        if (retiredTier === null) break;
+
+        const advancedPool = advanceSpawnPool(runtimeSpawnConfig, retiredTier);
+        newSpawnPoolMin = advancedPool.spawnPoolMin;
+        newSpawnPoolMax = advancedPool.spawnPoolMax;
+        runtimeSpawnConfig = { ...state.config, ...advancedPool };
+        board = markRetiredTiles(board, retiredTier);
+
+        const retirementEvent: RetirementFiredEvent = {
+          kind: 'retirement-fired',
+          retiredTier,
+          newSpawnPoolMin,
+          newSpawnPoolMax,
+        };
+        newEvents.push(retirementEvent);
+      }
+
+      // Spawn L-1 tiles
+      const { board: boardAfterSpawn, prngState: newPrng, spawned } = spawnTiles(
+        board,
+        chain.length,
+        runtimeSpawnConfig,
+        state.prngState
+      );
+      board = boardAfterSpawn;
+
       // Build tiles-spawned event
       if (spawned.length > 0) {
         const tilesSpawnedEvent: TilesSpawnedEvent = {
@@ -347,15 +385,6 @@ export function applyAction(state: GameState, action: Action): GameState {
         };
         newEvents.push(tilesSpawnedEvent);
       }
-
-      // Update maxTileEver
-      const newMaxTileEver = (
-        resultValue > state.maxTileEver ? resultValue : state.maxTileEver
-      );
-
-      // Retirement stub — checkRetirement goes here in Phase 4
-      const newSpawnPoolMin = state.spawnPoolMin;
-      const newSpawnPoolMax = state.spawnPoolMax;
 
       // Check loss condition
       const legalStart = hasLegalChainStart(board);

--- a/src/game-kernel/retirement.ts
+++ b/src/game-kernel/retirement.ts
@@ -1,26 +1,73 @@
-import type { TileValue, GameConfig } from './types.js';
+import type { Board, GameConfig, TileValue } from './types.js';
+
+const TILE_VALUES: readonly TileValue[] = [
+  2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
+];
+
+function nextTileValue(value: TileValue): TileValue | null {
+  const next = (value * 2) as TileValue;
+  return TILE_VALUES.includes(next) ? next : null;
+}
+
+function previousTileValue(value: TileValue): TileValue | null {
+  const previous = (value / 2) as TileValue;
+  return TILE_VALUES.includes(previous) ? previous : null;
+}
+
+function tierSevenStepsBelow(value: TileValue): TileValue | null {
+  let current: TileValue | null = value;
+  for (let i = 0; i < 7; i++) {
+    if (current === null) return null;
+    current = previousTileValue(current);
+  }
+  return current;
+}
 
 /**
  * Check whether a retirement should fire given the current max tile ever reached.
  * Returns the retiring tier value, or null if no retirement fires.
- *
- * STUB — Phase 4 implementation pending.
  */
 export function checkRetirement(
-  _maxTileEver: TileValue,
-  _currentSpawnPoolMax: TileValue
+  maxTileEver: TileValue,
+  currentSpawnPoolMax: TileValue
 ): TileValue | null {
-  throw new Error('NotImplemented: retirement — implement in Phase 4');
+  const triggerTier = nextTileValue(currentSpawnPoolMax);
+  if (triggerTier === null || maxTileEver < triggerTier) {
+    return null;
+  }
+  return tierSevenStepsBelow(currentSpawnPoolMax);
 }
 
 /**
  * Advance the spawn pool window by one tier.
- *
- * STUB — Phase 4 implementation pending.
  */
 export function advanceSpawnPool(
-  _config: GameConfig,
-  _retiredTier: TileValue
+  config: GameConfig,
+  retiredTier: TileValue
 ): Pick<GameConfig, 'spawnPoolMin' | 'spawnPoolMax' | 'spawnWeights'> {
-  throw new Error('NotImplemented: retirement — implement in Phase 4');
+  const spawnPoolMin = nextTileValue(retiredTier);
+  const spawnPoolMax = nextTileValue(config.spawnPoolMax);
+
+  if (spawnPoolMin === null || spawnPoolMax === null) {
+    return {
+      spawnPoolMin: config.spawnPoolMin,
+      spawnPoolMax: config.spawnPoolMax,
+      spawnWeights: config.spawnWeights,
+    };
+  }
+
+  const spawnWeights: Partial<Record<TileValue, number>> = { ...config.spawnWeights };
+  if (spawnWeights[spawnPoolMax] === undefined) {
+    spawnWeights[spawnPoolMax] = (spawnWeights[config.spawnPoolMax] ?? 1) / 2;
+  }
+
+  return { spawnPoolMin, spawnPoolMax, spawnWeights };
+}
+
+export function markRetiredTiles(board: Board, retiredTier: TileValue): Board {
+  return board.map(row =>
+    row.map(tile =>
+      tile.value === retiredTier ? { ...tile, retired: true } : tile
+    )
+  ) as Board;
 }

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -139,9 +139,23 @@ export function renderBoard(ctx: CanvasRenderingContext2D, s: RenderState): void
       let fillColor = color;
       if (inChain) fillColor = lighten(color, 0.35);
       else if (hasActiveChain && !isValidNext) fillColor = darken(color, 0.5);
+      else if (tile.retired) fillColor = darken(color, 0.35);
       ctx.fillStyle = fillColor;
       roundRect(ctx, x, y, TILE, TILE, RADIUS);
       ctx.fill();
+
+      if (tile.retired) {
+        ctx.save();
+        ctx.strokeStyle = 'rgba(255,255,255,0.35)';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(x + 14, y + TILE - 14);
+        ctx.lineTo(x + TILE - 14, y + 14);
+        ctx.moveTo(x + 24, y + TILE - 10);
+        ctx.lineTo(x + TILE - 10, y + 24);
+        ctx.stroke();
+        ctx.restore();
+      }
 
       // Chain highlight border; green pulse on valid-next tiles
       if (inChain) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -3,6 +3,7 @@ import type { GameState } from '../game-session/index.js';
 export interface HudElements {
   turn: HTMLElement;
   maxTile: HTMLElement;
+  spawnPool: HTMLElement;
   chainValue: HTMLElement;
   gameOver: HTMLElement;
   tuningToggle: HTMLButtonElement;
@@ -20,6 +21,10 @@ export function createHud(container: HTMLElement): HudElements {
   maxTileEl.className = 'hud-stat';
   maxTileEl.innerHTML = '<span class="hud-label">BEST</span><span class="hud-value" id="hud-max">—</span>';
 
+  const spawnPoolEl = document.createElement('div');
+  spawnPoolEl.className = 'hud-stat';
+  spawnPoolEl.innerHTML = '<span class="hud-label">POOL</span><span class="hud-value" id="hud-pool">2–256</span>';
+
   const chainValueEl = document.createElement('div');
   chainValueEl.className = 'hud-stat';
   chainValueEl.innerHTML = '<span class="hud-label">CHAIN</span><span class="hud-value" id="hud-chain">—</span>';
@@ -33,6 +38,7 @@ export function createHud(container: HTMLElement): HudElements {
   topBar.appendChild(turnEl);
   topBar.appendChild(chainValueEl);
   topBar.appendChild(maxTileEl);
+  topBar.appendChild(spawnPoolEl);
   topBar.appendChild(tuningToggle);
   container.appendChild(topBar);
 
@@ -50,6 +56,7 @@ export function createHud(container: HTMLElement): HudElements {
   return {
     turn: document.getElementById('hud-turn') as HTMLElement,
     maxTile: document.getElementById('hud-max') as HTMLElement,
+    spawnPool: document.getElementById('hud-pool') as HTMLElement,
     chainValue: document.getElementById('hud-chain') as HTMLElement,
     gameOver: gameOverEl,
     tuningToggle,
@@ -59,6 +66,7 @@ export function createHud(container: HTMLElement): HudElements {
 export function updateHud(hud: HudElements, state: GameState): void {
   hud.turn.textContent = String(state.turn);
   hud.maxTile.textContent = state.maxTileEver === 0 ? '—' : String(state.maxTileEver);
+  hud.spawnPool.textContent = `${state.spawnPoolMin}–${state.spawnPoolMax}`;
 
   if (state.phase === 'game-over') {
     const statsEl = document.getElementById('game-over-stats');

--- a/tests/game-kernel/retirement.test.ts
+++ b/tests/game-kernel/retirement.test.ts
@@ -1,8 +1,263 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import {
+  advanceSpawnPool,
+  checkRetirement,
+  markRetiredTiles,
+} from '../../src/game-kernel/retirement.js';
+import { applyAction, setTile, spawnTiles, validateChain } from '../../src/game-kernel/index.js';
+import type {
+  Board,
+  Cell,
+  CommitChainAction,
+  GameConfig,
+  GameState,
+  RetirementFiredEvent,
+  Tile,
+  TilesSpawnedEvent,
+  TileValue,
+} from '../../src/game-kernel/types.js';
 
-describe('retirement', () => {
-  it.todo('fires when player first creates a tile at next tier above spawn ceiling');
-  it.todo('spawn pool min advances by one tier after retirement');
-  it.todo('spawn pool max advances by one tier after retirement');
-  it.todo('retired tiles remain on board with retired=true flag');
+const CONFIG: GameConfig = {
+  gridRows: 3,
+  gridCols: 3,
+  ruleK: 2,
+  spawnPoolMin: 2,
+  spawnPoolMax: 256,
+  spawnWeights: {
+    2: 0,
+    4: 1,
+    8: 0,
+    16: 0,
+    32: 0,
+    64: 0,
+    128: 0,
+    256: 0,
+  },
+  prngSeed: 1,
+};
+
+function cell(row: number, col: number): Cell {
+  return { row: row as Cell['row'], col: col as Cell['col'] };
+}
+
+function emptyBoard(rows: number, cols: number): Board {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({ value: 0 as TileValue, retired: false }))
+  ) as Board;
+}
+
+function makeState(board: Board, overrides: Partial<GameState> = {}): GameState {
+  return {
+    board,
+    config: CONFIG,
+    phase: 'playing',
+    turn: 0,
+    maxTileEver: 256 as TileValue,
+    spawnPoolMin: 2 as TileValue,
+    spawnPoolMax: 256 as TileValue,
+    prngState: 123,
+    events: [],
+    ...overrides,
+  };
+}
+
+function tileAt(board: Board, row: number, col: number): Tile {
+  return board[row]![col]!;
+}
+
+function makeRetirementTriggerBoard(): Board {
+  let board = emptyBoard(3, 3);
+  board = setTile(board, cell(0, 0), { value: 256 as TileValue, retired: false });
+  board = setTile(board, cell(0, 1), { value: 256 as TileValue, retired: false });
+  board = setTile(board, cell(0, 2), { value: 2 as TileValue, retired: false });
+  board = setTile(board, cell(1, 0), { value: 2 as TileValue, retired: false });
+  board = setTile(board, cell(1, 1), { value: 4 as TileValue, retired: false });
+  board = setTile(board, cell(1, 2), { value: 8 as TileValue, retired: false });
+  board = setTile(board, cell(2, 0), { value: 16 as TileValue, retired: false });
+  board = setTile(board, cell(2, 1), { value: 32 as TileValue, retired: false });
+  board = setTile(board, cell(2, 2), { value: 64 as TileValue, retired: false });
+  return board;
+}
+
+function makeOvershootBoard(): Board {
+  let board = emptyBoard(3, 3);
+  board = setTile(board, cell(0, 0), { value: 1024 as TileValue, retired: false });
+  board = setTile(board, cell(0, 1), { value: 1024 as TileValue, retired: false });
+  board = setTile(board, cell(0, 2), { value: 2 as TileValue, retired: false });
+  board = setTile(board, cell(1, 0), { value: 4 as TileValue, retired: false });
+  board = setTile(board, cell(1, 1), { value: 8 as TileValue, retired: false });
+  board = setTile(board, cell(1, 2), { value: 16 as TileValue, retired: false });
+  board = setTile(board, cell(2, 0), { value: 32 as TileValue, retired: false });
+  board = setTile(board, cell(2, 1), { value: 64 as TileValue, retired: false });
+  board = setTile(board, cell(2, 2), { value: 128 as TileValue, retired: false });
+  return board;
+}
+
+describe('checkRetirement', () => {
+  it('does not fire below the next tier above the current spawn ceiling', () => {
+    expect(checkRetirement(256 as TileValue, 256 as TileValue)).toBeNull();
+  });
+
+  it('fires when player first creates a tile at next tier above spawn ceiling', () => {
+    expect(checkRetirement(512 as TileValue, 256 as TileValue)).toBe(2);
+  });
+
+  it('uses the shifted ceiling for later milestones', () => {
+    expect(checkRetirement(1024 as TileValue, 512 as TileValue)).toBe(4);
+  });
+
+  it('does not fire when the configured pool is narrower than the retirement window', () => {
+    expect(checkRetirement(4 as TileValue, 2 as TileValue)).toBeNull();
+  });
+
+  it('does not fire beyond the supported tile value range', () => {
+    expect(checkRetirement(8192 as TileValue, 8192 as TileValue)).toBeNull();
+  });
+
+  it('treats an invalid runtime ceiling as non-retiring', () => {
+    expect(checkRetirement(4 as TileValue, 3 as TileValue)).toBeNull();
+  });
+});
+
+describe('advanceSpawnPool', () => {
+  it('spawn pool min advances by one tier after retirement', () => {
+    const advanced = advanceSpawnPool(CONFIG, 2 as TileValue);
+    expect(advanced.spawnPoolMin).toBe(4);
+  });
+
+  it('spawn pool max advances by one tier after retirement', () => {
+    const advanced = advanceSpawnPool(CONFIG, 2 as TileValue);
+    expect(advanced.spawnPoolMax).toBe(512);
+  });
+
+  it('adds a derived weight for the new top tier when missing', () => {
+    const advanced = advanceSpawnPool(
+      { ...CONFIG, spawnWeights: { ...CONFIG.spawnWeights, 256: 2 } },
+      2 as TileValue
+    );
+    expect(advanced.spawnWeights[512]).toBe(1);
+  });
+
+  it('preserves an explicit configured weight for the new top tier', () => {
+    const advanced = advanceSpawnPool(
+      { ...CONFIG, spawnWeights: { ...CONFIG.spawnWeights, 512: 7 } },
+      2 as TileValue
+    );
+    expect(advanced.spawnWeights[512]).toBe(7);
+  });
+
+  it('derives the new top weight from 1 when the old top weight is missing', () => {
+    const advanced = advanceSpawnPool({ ...CONFIG, spawnWeights: {} }, 2 as TileValue);
+    expect(advanced.spawnWeights[512]).toBe(0.5);
+  });
+
+  it('falls back unchanged when the pool cannot advance further', () => {
+    const maxedConfig: GameConfig = {
+      ...CONFIG,
+      spawnPoolMin: 1024 as TileValue,
+      spawnPoolMax: 8192 as TileValue,
+    };
+    expect(advanceSpawnPool(maxedConfig, 8192 as TileValue)).toEqual({
+      spawnPoolMin: 1024,
+      spawnPoolMax: 8192,
+      spawnWeights: maxedConfig.spawnWeights,
+    });
+  });
+});
+
+describe('markRetiredTiles', () => {
+  it('retired tiles remain on board with retired=true flag', () => {
+    const board = makeRetirementTriggerBoard();
+    const marked = markRetiredTiles(board, 2 as TileValue);
+    expect(tileAt(marked, 0, 2)).toEqual({ value: 2, retired: true });
+    expect(tileAt(marked, 1, 0)).toEqual({ value: 2, retired: true });
+    expect(tileAt(marked, 1, 1)).toEqual({ value: 4, retired: false });
+  });
+
+  it('adjacent retired tiles remain mechanically chainable', () => {
+    let board = emptyBoard(2, 2);
+    board = setTile(board, cell(0, 0), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(0, 1), { value: 2 as TileValue, retired: true });
+    expect(validateChain(board, [cell(0, 0), cell(0, 1)]).valid).toBe(true);
+  });
+});
+
+describe("applyAction('commit-chain') retirement integration", () => {
+  it('fires retirement, advances runtime pool, marks old tier, then spawns from new pool', () => {
+    const state = makeState(makeRetirementTriggerBoard());
+    const action: CommitChainAction = {
+      kind: 'commit-chain',
+      chain: [cell(0, 0), cell(0, 1)],
+    };
+
+    const next = applyAction(state, action);
+    const retirement = next.events.find(
+      (e): e is RetirementFiredEvent => e.kind === 'retirement-fired'
+    );
+    const spawned = next.events.find(
+      (e): e is TilesSpawnedEvent => e.kind === 'tiles-spawned'
+    );
+
+    expect(retirement).toEqual({
+      kind: 'retirement-fired',
+      retiredTier: 2,
+      newSpawnPoolMin: 4,
+      newSpawnPoolMax: 512,
+    });
+    expect(next.spawnPoolMin).toBe(4);
+    expect(next.spawnPoolMax).toBe(512);
+    expect(next.maxTileEver).toBe(512);
+    expect(next.config.spawnPoolMin).toBe(2);
+    expect(next.config.spawnPoolMax).toBe(256);
+    expect(spawned?.spawned.every(s => s.value !== 2)).toBe(true);
+    expect(spawned?.spawned[0]?.value).toBe(4);
+    expect(next.events.map(e => e.kind)).toEqual([
+      'chain-resolved',
+      'retirement-fired',
+      'tiles-spawned',
+    ]);
+  });
+
+  it('cascades retirements until the spawn ceiling catches up to an overshoot result', () => {
+    const state = makeState(makeOvershootBoard());
+    const action: CommitChainAction = {
+      kind: 'commit-chain',
+      chain: [cell(0, 0), cell(0, 1)],
+    };
+
+    const next = applyAction(state, action);
+    const retirements = next.events.filter(
+      (e): e is RetirementFiredEvent => e.kind === 'retirement-fired'
+    );
+
+    expect(retirements).toEqual([
+      { kind: 'retirement-fired', retiredTier: 2, newSpawnPoolMin: 4, newSpawnPoolMax: 512 },
+      { kind: 'retirement-fired', retiredTier: 4, newSpawnPoolMin: 8, newSpawnPoolMax: 1024 },
+      { kind: 'retirement-fired', retiredTier: 8, newSpawnPoolMin: 16, newSpawnPoolMax: 2048 },
+    ]);
+    expect(next.spawnPoolMin).toBe(16);
+    expect(next.spawnPoolMax).toBe(2048);
+    expect(next.maxTileEver).toBe(2048);
+    expect(next.events.map(e => e.kind)).toEqual([
+      'chain-resolved',
+      'retirement-fired',
+      'retirement-fired',
+      'retirement-fired',
+      'tiles-spawned',
+      'game-over',
+    ]);
+  });
+});
+
+describe('retirement-aware spawning', () => {
+  it('can spawn the new top tier on later turns even when config lacks its weight', () => {
+    const config: GameConfig = {
+      ...CONFIG,
+      spawnPoolMin: 4 as TileValue,
+      spawnPoolMax: 512 as TileValue,
+      spawnWeights: {},
+    };
+    const { spawned } = spawnTiles(emptyBoard(1, 1), 2, config, 1);
+    expect(spawned).toEqual([{ cell: cell(0, 0), value: 512 }]);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,6 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: [
         'src/**/*.d.ts',
-        // retirement.ts is a Phase 4 stub — excluded until Phase 4 gate
-        'src/game-kernel/retirement.ts',
         // ui/ runs in the browser — unit coverage not enforced (ARCHITECTURE.md)
         'src/ui/**',
         // tuning-console DOM modules — no jsdom configured; covered by Evan UAT


### PR DESCRIPTION
## Summary

Implements Phase 4 / v1.5 tile retirement.

- Adds retirement trigger detection and sliding 8-tier spawn pool advancement in the pure game kernel.
- Cascades retirement within a single committed chain when a result overshoots multiple retirement thresholds.
- Marks retired on-board tiles with `retired: true` while preserving normal chain rules.
- Keeps runtime spawn pool state on `GameState`, leaving `GameConfig` as the starting config.
- Adds minimal UI legibility: HUD shows current pool and retired tiles render distinctly.
- Adds `docs/engineering/RETIREMENT_DESIGN_NOTES.md` with cascade-vs-one-step UAT and Phase 5 simulation metrics.

## Phase 4 Gate Notes

- First retirement at 512 is implemented and test-covered.
- Sliding pool remains 8 tiers wide: `2-256` -> `4-512` -> `8-1024` etc.
- Overshoot behavior currently cascades: a `2048` result from a `2-256` pool retires `2`, `4`, and `8` in the same transition.
- Emergent blocker behavior is preserved: retired tiles stay on board, remain mechanically normal, and stop spawning.
- Evan UAT still needs to judge whether cascade feels satisfyingly consequential or too punitive.

## Validation

- `npm test` — 127 passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run check-boundaries` — passed
- `npm run test:coverage` — passed; `retirement.ts` at 100% statements/functions/lines
- `npm run build` — passed