### PR TITLE
docs(ci): add branch workflow section and archive/v1 sentinel to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,15 @@ CI runs a dependency boundary check on every push. Violations are build failures
 
 ---
 
+## Branch Workflow
+
+See `docs/engineering/ARCHITECTURE.md` §Branch Strategy for the full rules. Short version: cut from `develop`, PR back to `develop`, never push directly to `develop` or `main`. Evan promotes `develop → main`.
+
+**Off-limits branches — do not read or use as context:**
+- `archive/v1` — abandoned prototype, different codebase entirely
+
+---
+
 ## What Requires Evan's Approval (do not proceed without it)
 
 1. Any edit to files in top-level `docs/` (the 7 design docs)


### PR DESCRIPTION
## Summary
- Adds a Branch Workflow section to CLAUDE.md pointing agents at ARCHITECTURE.md for the full rules (cut from develop, PR to develop, Evan promotes to main)
- Names archive/v1 as an off-limits branch so agents don't accidentally read the old prototype codebase for context

## Context
An explore agent recently read files from archive/v1 (an abandoned prototype with a completely different codebase) and used them as context for current work. This PR is the CLAUDE.md half of the fix; the other half was adding an ARCHIVED.md sentinel directly to the archive/v1 branch tip.

## Test plan
- [ ] Read CLAUDE.md and confirm the new section is clear and unambiguous
- [ ] Confirm archive/v1 branch now has an ARCHIVED.md at root (already pushed)

Generated with [Claude Code](https://claude.ai/claude-code)