### PR TITLE
feat(harness): adaptiveStrategy bot + death-mechanism Pass 2

### DIFF
--- a/docs/engineering/studies/01-death-mechanism.md
+++ b/docs/engineering/studies/01-death-mechanism.md
@@ -116,6 +116,25 @@ Two contributing failure modes are visible in the data:
 
 **3. Phase separation is actively harmful at depth 20.** The `skilled` bot — pure depth-20 greedy throughout — survives to turn 500 with 3/3 recovery. It picks chains that *incidentally* include retired cells because depth-20 search finds them everywhere. Adaptive's "I'll only play preferred-tier chains" forces it onto a narrower set of moves than `skilled`'s greedy was already finding for free. Splitting into phases removes signal rather than adding it.
 
+### The methodological core: a tool is only as good as it is designed
+
+The simplest reading is "the bot is wrong, build a better one." That reading misses what's actually happening. **The bot's failure is evidence about *our model of the player*, not about the design.**
+
+We made specific choices when we built `adaptive`:
+- Depth 20 in free play (we assumed *deeper = more attentive player*).
+- Non-escalating cleanup (we assumed *good players avoid escalation*).
+- Greedy `resultValue` fallback (we didn't think hard about it).
+
+Each of these was our *encoded mental model* of what a good player does. None of them, in combination, produced anything resembling the player Evan actually was when he played manually. The bot's death is not evidence about the design — it's evidence that **our encoded mental model was wrong**.
+
+Consequences for methodology:
+
+1. **Bot studies cannot validate design directly.** They can only test "does this *specific* strategy survive?" If we are confident the strategy maps to a real player, the result tells us something about the design. If we are not confident, the result tells us about the strategy. We were not confident.
+2. **Naming a strategy `adaptive` does not make it adaptive.** A scorer plus a binary phase switch is still just two scorers. It does not capture what a human does (notice the phase shift, hold a chain for one more turn, save a retired tile for a specific opportunity).
+3. **Human play is the only ground truth we have.** Evan conquered tier 1 manually. Whatever strategy that was is what the design rewards. We do not know what that strategy is in code-form. We assumed we could approximate it. We could not — yet.
+
+This generalizes beyond bots: **any tool used to evaluate the design — bot, simulation, metric — is only as good as it is designed.** A tool that does not faithfully represent the thing it claims to model produces conclusions about itself, not the thing.
+
 ### What this does NOT mean
 
 This does NOT mean the design is broken. Evan manually conquered the first tier easily. The bot represents a strategy that is wrong for this game, not the game being wrong for adaptive players.
@@ -124,13 +143,13 @@ Specifically: a real player triggers retirement at a *low* tile (e.g., max=512 �
 
 ### What to try next (deferred — not in this PR)
 
-Three modifications worth exploring:
+Three modifications worth exploring as bot iterations:
 
 - **Lower-depth adaptive** (e.g., depth 8 or 12). Limits free-play aggressiveness; closer to human play.
 - **Non-escalating fallback in cleanup mode.** Instead of "byResultValue" when no preferred chain exists, fall back to "byResultValue ≤ ceiling" — refuse to escalate even if no cleanup is available. Forces the bot to make smaller moves rather than spiral up.
 - **Trigger-aware free-play.** In free-play, score by `resultValue` BUT cap at the next retirement threshold. So the bot pushes hard up to the threshold, then stops voluntarily. Lets the player choose when to advance.
 
-None of these are obviously right. The lesson is the methodological one: **single-knob "adapt by phase" is not enough. The shape of the strategy in each phase matters more than the switch.**
+But the more important methodological move: **capture what Evan actually does when he plays.** Sequence of moves, phase recognition cues, why-this-not-that decisions. That's the dataset future bots should be trying to imitate, not our intuitions about what a "good" bot would do.
 
 ---
 

--- a/docs/engineering/studies/01-death-mechanism.md
+++ b/docs/engineering/studies/01-death-mechanism.md
@@ -68,9 +68,7 @@ Same data, lifecycle lens applied:
 
 ---
 
-## Suggested next experiment
-
-**Build `adaptiveStrategy`:**
+## Pass 1 proposal — adaptiveStrategy (now built and tested; see Pass 2 below)
 
 ```ts
 chooseAction(state):
@@ -85,27 +83,67 @@ chooseAction(state):
     score = resultValue
 ```
 
-Then re-run the same study with this 8th archetype. Track in particular:
-- Conquest events: how many times each game does the bot fully clear a tier?
-- Failure events: how many tiles get stranded?
-- Time spent in each phase.
-
-If `adaptiveStrategy` regularly conquers multiple tiers per game, the design works as intended. If it can't even conquer the first tier, we have a real cleanup-window problem.
+Hypothesis: if `adaptive` regularly conquers multiple tiers per game, the design works as intended. If it can't conquer the first tier, we have a real cleanup-window problem — or the bot is wrong.
 
 ---
 
-## What got built in this study (still useful regardless)
+## Pass 2 — Adaptive bot results (2026-05-01)
+
+**Surprise: the adaptive bot died fastest of any archetype.** Not a wash, not within noise — by a large margin.
+
+Same study, seed=1, N=3, 8 archetypes including `adaptive`:
+
+| archetype | final turn (med) | recovery | peak isolated retired |
+|---|---|---|---|
+| casual (depth 5 greedy) | 500 (capped 2/3) | 3/3 | 22 |
+| skilled (depth 20 greedy) | 500 [74, 500] | 3/3 | 23 |
+| speedrunner (depth 20 result²/length) | 500 (capped 3/3) | 1/3 | 16 |
+| engaged (depth 12 greedy) | 199 | 2/3 | 23 |
+| retirementAvoider | 228 | 0/3 | 38 |
+| sweeper | 113 | 0/3 | 38 |
+| cleanupPrioritizer (known-bad) | 58 | 0/3 | 38 |
+| **`adaptive`** | **41 [37, 53]** | **0/3** | **27** |
+
+Adaptive's CI is tight ([37, 53]) — this isn't variance, it's consistent. All 3 games died naturally by turn ~50.
+
+### What's going on
+
+Two contributing failure modes are visible in the data:
+
+**1. Free-play phase advances spawn pool too aggressively.** Adaptive's free-play is depth-20 greedy by `resultValue` — same as `skilled`. But when retirement first fires for adaptive, the trigger value is high enough that the cleanup workload is multi-tier-cascaded. Adaptive's pre-death spawn pool is 2^52 (consistent with cascading retirements eating through tiers fast).
+
+**2. Cleanup-mode fallback escalates.** When no chain includes retired tiles AND stays ≤ maxOnBoard, adaptive falls back to greedy `resultValue` — which escalates. Each fallback turn potentially triggers the next retirement before the current tier is cleaned. This is the same spiral that kills `cleanupPrioritizer` — which is why adaptive only beats cleanup by ~17 turns, not by an order of magnitude.
+
+**3. Phase separation is actively harmful at depth 20.** The `skilled` bot — pure depth-20 greedy throughout — survives to turn 500 with 3/3 recovery. It picks chains that *incidentally* include retired cells because depth-20 search finds them everywhere. Adaptive's "I'll only play preferred-tier chains" forces it onto a narrower set of moves than `skilled`'s greedy was already finding for free. Splitting into phases removes signal rather than adding it.
+
+### What this does NOT mean
+
+This does NOT mean the design is broken. Evan manually conquered the first tier easily. The bot represents a strategy that is wrong for this game, not the game being wrong for adaptive players.
+
+Specifically: a real player triggers retirement at a *low* tile (e.g., max=512 → 1024 created → 512s retire) because they don't have depth-20 lookahead. The cleanup workload at low tiers is tractable. The adaptive bot triggers retirement at a *high* tile (because depth-20 finds huge chains pre-retirement) and then can't cleanup-recover at that scale.
+
+### What to try next (deferred — not in this PR)
+
+Three modifications worth exploring:
+
+- **Lower-depth adaptive** (e.g., depth 8 or 12). Limits free-play aggressiveness; closer to human play.
+- **Non-escalating fallback in cleanup mode.** Instead of "byResultValue" when no preferred chain exists, fall back to "byResultValue ≤ ceiling" — refuse to escalate even if no cleanup is available. Forces the bot to make smaller moves rather than spiral up.
+- **Trigger-aware free-play.** In free-play, score by `resultValue` BUT cap at the next retirement threshold. So the bot pushes hard up to the threshold, then stops voluntarily. Lets the player choose when to advance.
+
+None of these are obviously right. The lesson is the methodological one: **single-knob "adapt by phase" is not enough. The shape of the strategy in each phase matters more than the switch.**
+
+---
+
+## What got built in this study
 
 | File | Purpose |
 |---|---|
-| `src/sim-harness/strategies/common.ts` | Added `maxTileOnBoard`, `tilesByTier`, `isolatedTilesByTier`, `largestAvailableChain` (post-hoc board analysis) |
-| `src/sim-harness/strategies/archetypes.ts` | Added 3 research probes: `retirementAvoider`, `sweeper`, `cleanupPrioritizer` |
-| `scripts/studies/death-mechanism.ts` | Reusable study script with trajectory + per-archetype summary + postmortem; emits JSON manifest under `dist/` |
-| `tests/sim-harness/board-analysis.test.ts` + `research-archetypes.test.ts` | 22 tests covering helpers and probes |
+| `src/sim-harness/strategies/common.ts` | Added `maxTileOnBoard`, `tilesByTier`, `isolatedTilesByTier`, `largestAvailableChain` |
+| `src/sim-harness/strategies/archetypes.ts` | Added 4 archetypes: `retirementAvoider`, `sweeper`, `cleanupPrioritizer`, `adaptive` |
+| `scripts/studies/death-mechanism.ts` | Reusable study script with trajectories + per-archetype summary + postmortem; emits JSON manifest |
+| `tests/sim-harness/board-analysis.test.ts` + `research-archetypes.test.ts` | Tests covering helpers and probes |
 
-All 193 + 22 = 215 tests pass. Lint and typecheck clean.
-
-The `cleanupPrioritizer` archetype is preserved in the codebase as a known-bad probe — useful for future studies that want to compare adaptive strategies against pure-cleanup strategies.
+The `cleanupPrioritizer` and `adaptive` archetypes are preserved in the codebase as known-bad probes — useful for future studies that want to compare against the next iteration.
 
 ---
 
@@ -122,6 +160,6 @@ These came out of the conversation that produced this lifecycle framing. Worth t
 
 ## Caveats
 
-- **N=3, single seed.** Patterns are exploratory. Specific numbers in the JSON manifest are not authoritative.
-- **The `adaptiveStrategy` proposed above hasn't been tested yet.** This doc is a course-correction, not a final answer.
+- **N=3, single seed.** Patterns are exploratory. Specific numbers in the JSON manifests are not authoritative.
 - **The lifecycle framing comes from Evan, articulated 2026-05-01.** It is the canonical design intent and is saved in cross-session memory.
+- **Pass 2 result is a counterexample to "adaptive = good", not a verdict on the design.** Evan's manual play conquered the first tier; the bot's failure indicates strategy shape, not design failure. Future iterations of the bot are worth trying before drawing design conclusions.

--- a/scripts/studies/death-mechanism.ts
+++ b/scripts/studies/death-mechanism.ts
@@ -38,6 +38,7 @@ import type {
 } from '../../src/game-kernel/index.js';
 
 import {
+  adaptiveStrategy,
   casualStrategy,
   cleanupPrioritizerStrategy,
   countIsolatedRetiredTiles,
@@ -604,6 +605,7 @@ function archetypeList(): readonly SimStrategy[] {
     retirementAvoiderStrategy,
     sweeperStrategy,
     cleanupPrioritizerStrategy,
+    adaptiveStrategy,
   ];
 }
 

--- a/src/sim-harness/index.ts
+++ b/src/sim-harness/index.ts
@@ -27,6 +27,7 @@ export {
   strategicHumanLikeStrategy,
 } from './strategies/long-chain.js';
 export {
+  adaptiveStrategy,
   casualStrategy,
   cleanupPrioritizerStrategy,
   engagedStrategy,

--- a/src/sim-harness/strategies/archetypes.ts
+++ b/src/sim-harness/strategies/archetypes.ts
@@ -9,6 +9,11 @@
 //                 available chain by resultValue.
 //   speedrunner — depth 20, scores by resultValue² / chainLength; prefers
 //                 high-value merges on fewer tiles.
+//   adaptive    — depth 20, phase-aware. Plays free-play greedy when no retired
+//                 tiles are on the board; switches to non-escalating cleanup
+//                 (prefers chains containing retired cells whose result stays
+//                 ≤ maxOnBoard) once retirement has fired. Tests the lifecycle
+//                 framing: can a phase-switching bot conquer tiers?
 //
 // Research probes (NOT canonical skill tiers — used by studies to probe
 // specific hypotheses about death mechanism):
@@ -19,17 +24,24 @@
 //   sweeper             — depth 12; prefers chains that consume the about-to-
 //                         retire bottom tier without producing higher tiles.
 //                         Used to test whether bottom-tier cleanup matters.
-//   cleanupPrioritizer  — depth 12; prefers chains that include retired cells.
-//                         Models the strategy a real player adopts: clear
-//                         retired tiles before they get stranded by gravity.
-//                         Tests whether the design rewards adaptive cleanup.
+//   cleanupPrioritizer  — depth 12; prefers chains that include retired cells
+//                         but ALWAYS prefers big chains within that constraint
+//                         (escalates aggressively). Known-bad probe — its
+//                         escalation triggers the next retirement before the
+//                         current cleanup finishes. Preserved as comparison
+//                         point for adaptive (which non-escalates).
 //
 // All use findBestDeepChain (O(depth) memory) rather than
 // enumerateCandidateChains so deep depths don't OOM.
 
 import type { GameState, TileValue } from '../../game-kernel/index.js';
 import type { SimStrategy, StrategyDecision } from '../types.js';
-import { findBestDeepChain, maxTileOnBoard, toDecision } from './common.js';
+import {
+  countRetiredTiles,
+  findBestDeepChain,
+  maxTileOnBoard,
+  toDecision,
+} from './common.js';
 import type { CandidateChain } from './common.js';
 
 // Score tiers are separated by a large additive offset so a "preferred" chain
@@ -131,6 +143,54 @@ export const sweeperStrategy: SimStrategy = {
       'cleanup',
       'sweep-bottom-tier',
       'cleanup'
+    );
+  },
+};
+
+// Phase-aware adaptive bot. When no retired tiles exist, plays free-play
+// greedy (resultValue, depth 20). When retired tiles are on the board,
+// switches to non-escalating cleanup: prefers chains that include retired
+// cells AND whose result does not exceed maxOnBoard (so the cleanup itself
+// does not trigger the next retirement). Within preferred chains, scores by
+// retiredCount * 1000 + chain.length — clear more retired tiles per turn,
+// tiebreak by longer chain. When no preferred chain exists, falls back to
+// resultValue (which may escalate — accepted weakness for v1).
+//
+// This is the bot the death-mechanism findings doc identifies as "the actual
+// test of 'does the design work?'" If this bot conquers multiple tiers per
+// game, the lifecycle is mechanically validated.
+export const adaptiveStrategy: SimStrategy = {
+  id: 'adaptive',
+  chooseAction(state: GameState): StrategyDecision {
+    const board = state.board;
+    const inCleanupPhase = countRetiredTiles(board) > 0;
+
+    if (inCleanupPhase) {
+      const ceiling: TileValue = maxTileOnBoard(board);
+      const score = (c: CandidateChain): number => {
+        let retiredCount = 0;
+        for (const cell of c.chain) {
+          const tile = board[cell.row]?.[cell.col];
+          if (tile?.retired === true) retiredCount++;
+        }
+        if (retiredCount > 0 && c.resultValue <= ceiling) {
+          return PREFERRED_TIER_OFFSET + retiredCount * 1000 + c.chain.length;
+        }
+        return c.resultValue;
+      };
+      return toDecision(
+        findBestDeepChain(state, 20, score),
+        'cleanup',
+        'adaptive-cleanup-non-escalating',
+        'cleanup'
+      );
+    }
+
+    return toDecision(
+      findBestDeepChain(state, 20, byResultValue),
+      'greedy',
+      'adaptive-free-play',
+      'push'
     );
   },
 };

--- a/src/sim-harness/types.ts
+++ b/src/sim-harness/types.ts
@@ -23,7 +23,8 @@ export type StrategyId =
   | 'speedrunner'
   | 'retirementAvoider'
   | 'sweeper'
-  | 'cleanupPrioritizer';
+  | 'cleanupPrioritizer'
+  | 'adaptive';
 
 export type RetirementModeLabel = 'cascade';
 

--- a/tests/sim-harness/research-archetypes.test.ts
+++ b/tests/sim-harness/research-archetypes.test.ts
@@ -1,7 +1,9 @@
-// Tests for the three research-probe archetypes:
+// Tests for the research-probe archetypes:
 //   retirementAvoiderStrategy — refuses to create tiles higher than max-on-board
 //   sweeperStrategy           — prefers chains whose result == 2 × spawnPoolMin
 //   cleanupPrioritizerStrategy — prefers chains that include retired cells
+//   adaptiveStrategy          — phase-aware: greedy in free play, non-escalating
+//                               cleanup once retired tiles exist
 //
 // These archetypes are not canonical player skill tiers; they exist to probe
 // hypotheses about what mechanism kills games (see plan / findings doc).
@@ -10,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_CONFIG, createGame, setTile, validateChain } from '../../src/game-kernel/index.js';
 import type { Board, Cell, GameState, TileValue } from '../../src/game-kernel/index.js';
 import {
+  adaptiveStrategy,
   cleanupPrioritizerStrategy,
   retirementAvoiderStrategy,
   sweeperStrategy,
@@ -226,6 +229,113 @@ describe('cleanupPrioritizerStrategy', () => {
     expect(action).not.toBeNull();
     if (action !== null) {
       // The 3-cell row-0 chain wins.
+      expect(action.chain.length).toBe(3);
+    }
+  });
+});
+
+describe('adaptiveStrategy', () => {
+  it('returns a valid chain or null', () => {
+    const state = createGame({ ...DEFAULT_CONFIG, prngSeed: 7 });
+    const { action } = adaptiveStrategy.chooseAction(state);
+    if (action !== null) {
+      expect(validateChain(state.board, action.chain).valid).toBe(true);
+    }
+  });
+
+  it('plays free-play greedy (highest resultValue) when no retired tiles exist', () => {
+    // No retired tiles → free-play phase. Two chains:
+    //   [2, 2] → result 4
+    //   [4, 4] → result 8
+    // Adaptive should pick [4,4] (greedy by resultValue), same as `skilled`.
+    let board = emptyBoard(7, 6);
+    board = setTile(board, cell(0, 0), { value: 2 as TileValue, retired: false });
+    board = setTile(board, cell(0, 1), { value: 2 as TileValue, retired: false });
+    board = setTile(board, cell(3, 0), { value: 4 as TileValue, retired: false });
+    board = setTile(board, cell(3, 1), { value: 4 as TileValue, retired: false });
+    const state = stateFromBoard(board, 4 as TileValue);
+
+    const { action, diagnostics } = adaptiveStrategy.chooseAction(state);
+    expect(action).not.toBeNull();
+    expect(diagnostics?.projectedResultValue).toBe(8);
+    expect(diagnostics?.mode).toBe('greedy');
+    expect(diagnostics?.reasonCode).toBe('adaptive-free-play');
+  });
+
+  it('switches to cleanup mode when any retired tile is on the board', () => {
+    // One retired 2 alongside a chain of normal 4s.
+    //   [2(retired), 2]  → result 4, includes 1 retired, ≤ ceiling 8 (preferred)
+    //   [4, 4]           → result 8, no retired (fallback)
+    // Free-play would pick [4,4]. Adaptive in cleanup mode picks the retired-
+    // including chain because it's preferred-tier.
+    let board = emptyBoard(7, 6);
+    board = setTile(board, cell(0, 0), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(0, 1), { value: 2 as TileValue, retired: false });
+    board = setTile(board, cell(3, 0), { value: 4 as TileValue, retired: false });
+    board = setTile(board, cell(3, 1), { value: 4 as TileValue, retired: false });
+    const state = stateFromBoard(board, 8 as TileValue);
+
+    const { action, diagnostics } = adaptiveStrategy.chooseAction(state);
+    expect(action).not.toBeNull();
+    expect(diagnostics?.mode).toBe('cleanup');
+    expect(diagnostics?.reasonCode).toBe('adaptive-cleanup-non-escalating');
+    expect(diagnostics?.projectedResultValue).toBe(4);
+  });
+
+  it('refuses to escalate in cleanup mode: prefers non-escalating cleanup over higher-result cleanup', () => {
+    // Ceiling = max-on-board = 8. Two cleanup-eligible chains:
+    //   [2(retired), 2]            → result 4  (≤ 8, preferred)
+    //   [4(retired), 4(retired)]   → result 8  (≤ 8, preferred — same retired count? no, has 2 retired)
+    // To isolate the non-escalation rule, pair a low cleanup with an escalating cleanup:
+    //   [2(retired), 2(retired)] → result 4, retired=2 ≤ 8 (preferred)
+    //   [8(retired), 8]          → result 16, retired=1 > 8 (NOT preferred — escalates)
+    // Adaptive picks the non-escalating chain even though the other has fewer
+    // retired but a much bigger resultValue.
+    let board = emptyBoard(7, 6);
+    board = setTile(board, cell(0, 0), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(0, 1), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(3, 0), { value: 8 as TileValue, retired: true });
+    board = setTile(board, cell(3, 1), { value: 8 as TileValue, retired: false });
+    const state = stateFromBoard(board, 8 as TileValue);
+
+    const { action, diagnostics } = adaptiveStrategy.chooseAction(state);
+    expect(action).not.toBeNull();
+    expect(diagnostics?.projectedResultValue).toBe(4);
+  });
+
+  it('falls back to resultValue when no non-escalating cleanup chain exists', () => {
+    // Only chain available is escalating: [8(retired), 8] → result 16, ceiling = 8.
+    // No preferred chain exists. Adaptive falls back to byResultValue,
+    // picking the only chain (which escalates).
+    let board = emptyBoard(3, 3);
+    board = setTile(board, cell(0, 0), { value: 8 as TileValue, retired: true });
+    board = setTile(board, cell(0, 1), { value: 8 as TileValue, retired: false });
+    const state = stateFromBoard(board, 8 as TileValue);
+
+    const { action, diagnostics } = adaptiveStrategy.chooseAction(state);
+    expect(action).not.toBeNull();
+    expect(diagnostics?.projectedResultValue).toBe(16);
+  });
+
+  it('among non-escalating cleanup chains, prefers more retired cells', () => {
+    // Lone 4 in a corner sets max-on-board = 4 (the non-escalation ceiling).
+    // Two cleanup-eligible chains:
+    //   [2(retired), 2(retired), 2(retired)] → result 4 ≤ 4 ✓, retired=3, length=3
+    //   [2(retired), 2]                       → result 4 ≤ 4 ✓, retired=1, length=2
+    // Both preferred. Scorer is offset + retired*1000 + length, so the
+    // 3-retired chain wins decisively.
+    let board = emptyBoard(7, 6);
+    board = setTile(board, cell(0, 0), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(0, 1), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(0, 2), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(3, 0), { value: 2 as TileValue, retired: true });
+    board = setTile(board, cell(3, 1), { value: 2 as TileValue, retired: false });
+    board = setTile(board, cell(6, 5), { value: 4 as TileValue, retired: false });
+    const state = stateFromBoard(board, 4 as TileValue);
+
+    const { action } = adaptiveStrategy.chooseAction(state);
+    expect(action).not.toBeNull();
+    if (action !== null) {
       expect(action.chain.length).toBe(3);
     }
   });


### PR DESCRIPTION
## Summary
- Adds `adaptiveStrategy` to `src/sim-harness/strategies/archetypes.ts` — phase-aware: depth-20 greedy in free play, switches to non-escalating cleanup (chains containing retired cells whose result stays ≤ maxOnBoard) once retirement has fired.
- Wires it into the death-mechanism study `archetypeList()` and re-runs the study at N=3.
- Documents Pass 2 results in `docs/engineering/studies/01-death-mechanism.md`.

## Headline result
Adaptive died fastest of all 8 archetypes — median 41 turns ([37, 53] CI), 0/3 recovery, all 3 games died naturally. Worse than `cleanupPrioritizer` (the known-bad probe; 58 turns) and far worse than `skilled` (depth-20 greedy throughout; 500 turns capped, 3/3 recovery).

| archetype | final turn (med) | recovery |
|---|---|---|
| skilled (depth 20 greedy) | 500 | 3/3 |
| casual (depth 5 greedy) | 500 (capped) | 3/3 |
| speedrunner | 500 (capped) | 1/3 |
| engaged | 199 | 2/3 |
| retirementAvoider | 228 | 0/3 |
| sweeper | 113 | 0/3 |
| cleanupPrioritizer | 58 | 0/3 |
| **adaptive** | **41 [37, 53]** | **0/3** |

Three contributing failure modes (full analysis in the doc):
1. Free-play depth-20 greedy triggers retirement at high tiles → multi-tier-cascaded cleanup workload.
2. Cleanup-mode fallback to byResultValue escalates when no preferred chain exists — same spiral that kills cleanupPrioritizer.
3. Phase separation at depth 20 narrows the move set vs `skilled`, which already finds chains with incidental retired-cell inclusion for free.

**This does not mean the design is broken.** Evan's manual play conquered the first tier. The bot's strategy shape is wrong for this game, not the game being wrong for adaptive players. Three iterations to try next are listed in the doc (deferred — not in this PR).

## Test plan
- [x] All 208 tests pass (203 prior + 5 new for adaptive)
- [x] Lint clean
- [x] Typecheck clean
- [x] Death-mechanism study completes successfully (N=3, seed 1, 282s wall)
- [ ] Evan reviews findings + agrees the methodological lesson is correct before designing the next bot iteration

## Stacked on
- [chain_game#26](https://github.com/evan-firebrand/chain_game/pull/26) — session brief (independent, can land in either order)