### PR TITLE
feat(session): per-turn play recording (PlaylogRecorder + UI download)

### DIFF
--- a/src/game-session/playlog.ts
+++ b/src/game-session/playlog.ts
@@ -1,0 +1,79 @@
+import type {
+  Board,
+  Cell,
+  GameEvent,
+  GameState,
+  TileValue,
+} from '../game-kernel/index.js';
+import type { GameSession } from './session.js';
+
+export interface PlaylogRecord {
+  readonly turn: number;
+  readonly timestamp: string;
+  readonly boardBefore: Board;
+  readonly chainPlayed: readonly Cell[];
+  readonly resultValue: TileValue;
+  readonly boardAfter: Board;
+  readonly kernelEvents: readonly GameEvent[];
+  readonly spawnPoolMinBefore: TileValue;
+  readonly spawnPoolMaxBefore: TileValue;
+  readonly maxTileEverBefore: TileValue;
+}
+
+export class PlaylogRecorder {
+  private records: PlaylogRecord[] = [];
+  private previousState: GameState;
+  private unsubscribe: () => void;
+
+  constructor(session: GameSession) {
+    this.previousState = session.getState();
+    this.unsubscribe = this.subscribe(session);
+  }
+
+  /**
+   * Re-attach to a new session (e.g. after a Play Again rewire).
+   * Records accumulated so far are preserved.
+   */
+  attachSession(session: GameSession): void {
+    this.unsubscribe();
+    this.previousState = session.getState();
+    this.unsubscribe = this.subscribe(session);
+  }
+
+  getRecords(): readonly PlaylogRecord[] {
+    return this.records;
+  }
+
+  serialize(): string {
+    return this.records.map(r => JSON.stringify(r)).join('\n');
+  }
+
+  dispose(): void {
+    this.unsubscribe();
+  }
+
+  private subscribe(session: GameSession): () => void {
+    return session.on(event => {
+      const chainResolved = event.kernelEvents.find(
+        (e): e is Extract<GameEvent, { kind: 'chain-resolved' }> =>
+          e.kind === 'chain-resolved'
+      );
+      if (chainResolved !== undefined) {
+        const record: PlaylogRecord = {
+          turn: event.turn,
+          timestamp: new Date().toISOString(),
+          boardBefore: this.previousState.board,
+          chainPlayed: chainResolved.chain,
+          resultValue: chainResolved.resultValue,
+          boardAfter: event.state.board,
+          kernelEvents: event.kernelEvents,
+          spawnPoolMinBefore: this.previousState.spawnPoolMin,
+          spawnPoolMaxBefore: this.previousState.spawnPoolMax,
+          maxTileEverBefore: this.previousState.maxTileEver,
+        };
+        this.records.push(record);
+      }
+      this.previousState = event.state;
+    });
+  }
+}

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -16,6 +16,8 @@ import { attachInput } from './input.js';
 import type { InputCallbacks } from './input.js';
 import { createHud, updateHud, updateChainPreview } from './hud.js';
 import { mountTuningConsole } from '../tuning-console/console.js';
+import { PlaylogRecorder } from '../game-session/playlog.js';
+import { mountPlaylogControls } from './playlog-controls.js';
 
 function injectStyles(): void {
   const style = document.createElement('style');
@@ -57,6 +59,17 @@ function injectStyles(): void {
       line-height: 1;
     }
     .hud-tuning-toggle:hover { background: #3a4060; }
+    .hud-playlog-download {
+      background: #2a3050;
+      color: #fff;
+      border: 1px solid #445;
+      border-radius: 6px;
+      padding: 6px 10px;
+      cursor: pointer;
+      font-size: 12px;
+      line-height: 1;
+    }
+    .hud-playlog-download:hover { background: #3a4060; }
     canvas {
       display: block;
       touch-action: none;
@@ -231,6 +244,7 @@ function mount(): void {
 
   let unsubscribe = session.on(() => { render(); });
   let detach = attachInput(canvas, session.getState().config.gridRows, session.getState().config.gridCols, makeInputCallbacks());
+  const playlog = new PlaylogRecorder(session);
 
   function rewireSession(newSession: GameSession): void {
     unsubscribe();
@@ -240,6 +254,7 @@ function mount(): void {
     resizeCanvas(cfg);
     unsubscribe = session.on(() => { render(); });
     detach = attachInput(canvas, cfg.gridRows, cfg.gridCols, makeInputCallbacks());
+    playlog.attachSession(session);
   }
 
   const tuning = mountTuningConsole({
@@ -253,6 +268,8 @@ function mount(): void {
       render();
     },
   });
+
+  mountPlaylogControls(hud.tuningToggle.parentElement ?? app, playlog);
 
   hud.tuningToggle.addEventListener('click', () => {
     if (document.body.hasAttribute('data-console-open')) {

--- a/src/ui/playlog-controls.ts
+++ b/src/ui/playlog-controls.ts
@@ -1,0 +1,25 @@
+import type { PlaylogRecorder } from '../game-session/playlog.js';
+
+export function mountPlaylogControls(
+  container: HTMLElement,
+  recorder: PlaylogRecorder
+): void {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'hud-playlog-download';
+  button.textContent = 'Download playlog';
+  button.addEventListener('click', () => {
+    const data = recorder.serialize();
+    const blob = new Blob([data], { type: 'application/jsonl' });
+    const url = URL.createObjectURL(blob);
+    const stamp = new Date().toISOString().replace(/:/g, '-').replace(/\..+$/, '');
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `playlog-${stamp}.jsonl`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
+  container.appendChild(button);
+}

--- a/tests/game-session/playlog.test.ts
+++ b/tests/game-session/playlog.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { GameSession, DEFAULT_CONFIG } from '../../src/game-session/index.js';
+import { PlaylogRecorder } from '../../src/game-session/playlog.js';
+import type {
+  Cell,
+  CommitChainAction,
+  GameConfig,
+} from '../../src/game-session/index.js';
+
+const CONFIG: GameConfig = { ...DEFAULT_CONFIG, prngSeed: 42 };
+
+function cell(row: number, col: number): Cell {
+  return { row: row as Cell['row'], col: col as Cell['col'] };
+}
+
+/** Find any valid 2-cell same-value adjacent chain on the current board. */
+function findAdjacentPair(session: GameSession): Cell[] | null {
+  const state = session.getState();
+  for (let r = 0; r < state.config.gridRows; r++) {
+    for (let c = 0; c < state.config.gridCols; c++) {
+      const v = state.board[r]?.[c]?.value ?? 0;
+      if (v === 0) continue;
+      if (c + 1 < state.config.gridCols && state.board[r]?.[c + 1]?.value === v) {
+        return [cell(r, c), cell(r, c + 1)];
+      }
+      if (r + 1 < state.config.gridRows && state.board[r + 1]?.[c]?.value === v) {
+        return [cell(r, c), cell(r + 1, c)];
+      }
+    }
+  }
+  return null;
+}
+
+describe('PlaylogRecorder', () => {
+  it('accumulates one record per commit-chain dispatch', () => {
+    const session = new GameSession(CONFIG);
+    const recorder = new PlaylogRecorder(session);
+    expect(recorder.getRecords().length).toBe(0);
+
+    const chain = findAdjacentPair(session);
+    expect(chain).not.toBeNull();
+    if (chain === null) return;
+    const action: CommitChainAction = { kind: 'commit-chain', chain };
+    session.dispatch(action);
+
+    expect(recorder.getRecords().length).toBe(1);
+  });
+
+  it('records boardBefore = state BEFORE the chain (not after)', () => {
+    const session = new GameSession(CONFIG);
+    const before = session.getState();
+    const recorder = new PlaylogRecorder(session);
+
+    const chain = findAdjacentPair(session);
+    if (chain === null) throw new Error('no chain found');
+    session.dispatch({ kind: 'commit-chain', chain });
+
+    const records = recorder.getRecords();
+    expect(records.length).toBe(1);
+    const rec = records[0];
+    if (rec === undefined) throw new Error('no record');
+    expect(rec.boardBefore).toEqual(before.board);
+    // Sanity: post-state board differs from boardBefore (chain modified the board).
+    expect(rec.boardAfter).not.toEqual(before.board);
+  });
+
+  it('records boardAfter matching the post-dispatch state', () => {
+    const session = new GameSession(CONFIG);
+    const recorder = new PlaylogRecorder(session);
+
+    const chain = findAdjacentPair(session);
+    if (chain === null) throw new Error('no chain found');
+    session.dispatch({ kind: 'commit-chain', chain });
+
+    const after = session.getState();
+    const rec = recorder.getRecords()[0];
+    if (rec === undefined) throw new Error('no record');
+    expect(rec.boardAfter).toEqual(after.board);
+  });
+
+  it('kernelEvents includes chain-resolved and tiles-spawned', () => {
+    const session = new GameSession(CONFIG);
+    const recorder = new PlaylogRecorder(session);
+
+    const chain = findAdjacentPair(session);
+    if (chain === null) throw new Error('no chain found');
+    session.dispatch({ kind: 'commit-chain', chain });
+
+    const rec = recorder.getRecords()[0];
+    if (rec === undefined) throw new Error('no record');
+    const kinds = rec.kernelEvents.map(e => e.kind);
+    expect(kinds).toContain('chain-resolved');
+    expect(kinds).toContain('tiles-spawned');
+  });
+
+  it('records game-over kernel event when emitted on the same dispatch', () => {
+    // Drive turns until game-over. We use a small grid + tight seed to converge
+    // by replaying chains; if we don't hit game-over after many turns, skip.
+    const session = new GameSession(CONFIG);
+    const recorder = new PlaylogRecorder(session);
+
+    let sawGameOver = false;
+    for (let i = 0; i < 500; i++) {
+      const chain = findAdjacentPair(session);
+      if (chain === null) break;
+      session.dispatch({ kind: 'commit-chain', chain });
+      if (session.getState().phase === 'game-over') {
+        const rec = recorder.getRecords()[recorder.getRecords().length - 1];
+        if (rec !== undefined) {
+          sawGameOver = rec.kernelEvents.some(e => e.kind === 'game-over');
+        }
+        break;
+      }
+    }
+    // Either we saw game-over (and asserted it appears in the last record's events)
+    // or the test board never reaches game-over within 500 turns — in which case
+    // we can't assert and skip. Use a soft expect: if game-over phase reached,
+    // last record must include the event.
+    if (session.getState().phase === 'game-over') {
+      expect(sawGameOver).toBe(true);
+    }
+  });
+
+  it('serialize() produces valid JSONL with one line per record', () => {
+    const session = new GameSession(CONFIG);
+    const recorder = new PlaylogRecorder(session);
+
+    for (let i = 0; i < 3; i++) {
+      const chain = findAdjacentPair(session);
+      if (chain === null) break;
+      session.dispatch({ kind: 'commit-chain', chain });
+    }
+
+    const records = recorder.getRecords();
+    expect(records.length).toBeGreaterThan(0);
+
+    const lines = recorder.serialize().split('\n');
+    expect(lines.length).toBe(records.length);
+    for (const line of lines) {
+      expect(() => JSON.parse(line) as unknown).not.toThrow();
+    }
+  });
+
+  it('dispose() unsubscribes — further dispatches do not append records', () => {
+    const session = new GameSession(CONFIG);
+    const recorder = new PlaylogRecorder(session);
+
+    const firstChain = findAdjacentPair(session);
+    if (firstChain === null) throw new Error('no chain found');
+    session.dispatch({ kind: 'commit-chain', chain: firstChain });
+
+    const beforeDispose = recorder.getRecords().length;
+    recorder.dispose();
+
+    const nextChain = findAdjacentPair(session);
+    if (nextChain !== null) {
+      session.dispatch({ kind: 'commit-chain', chain: nextChain });
+    }
+
+    expect(recorder.getRecords().length).toBe(beforeDispose);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `PlaylogRecorder` in `src/game-session/playlog.ts` — subscribes to session events, pairs each turn's BEFORE state with the AFTER state from the event payload, accumulates per-turn `PlaylogRecord` entries.
- Adds `mountPlaylogControls` in `src/ui/playlog-controls.ts` — \"Download playlog\" button in the HUD that exports accumulated records as JSONL via Blob + `URL.createObjectURL`.
- Wires both into `src/ui/app.ts`. Auto-records every game; user clicks button to export.
- 7 vitest specs in `tests/game-session/playlog.test.ts`.

## Why
Captures the dataset that PR-C will use to fit `weightedHeuristic` weights to actual human play — the methodological response to the Pass 2 finding (PRs #26, #27) that bots designed from our intuitions don't represent how Evan plays.

## Per-turn record shape
\`\`\`ts
interface PlaylogRecord {
  turn, timestamp, boardBefore, chainPlayed, resultValue,
  boardAfter, kernelEvents, spawnPoolMinBefore, spawnPoolMaxBefore, maxTileEverBefore
}
\`\`\`
All five features the future weight-fitting needs are computable from this record without going back to the kernel.

## Deviation from the original spec
Added a `PlaylogRecorder.attachSession()` method beyond the original brief. Without it, clicking \"Play Again\" (which rewires the session in `app.ts`) would silently stop recording or lose accumulated records. \`attachSession\` lets the recorder follow the rewire while preserving prior records — which matches how a recording tool should behave.

## Test plan
- [x] 210/210 tests pass (203 existing + 7 new)
- [x] Lint, typecheck, boundary check clean
- [x] Manual: dev server, played 3 chains, clicked Download, opened the resulting `.jsonl`. One line per turn, all 10 fields present, monotonic turns, result values are powers of 2.
- [ ] Evan plays 5–10 games into the recorder so we have a calibration corpus for PR-C

## Stacked / parallel
- Independent of [chain_game#TBD](feat/weighted-heuristic-bot) (PR-B). Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)