### PR TITLE
feat(ui): luminous-crystal redesign — animations, glow, conquest celebration

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,25 +3,75 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>Chain Game</title>
+    <meta name="theme-color" content="#08091a" />
+    <title>Chain — a luminous puzzle</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@400;500;700;800;900&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
+      :root {
+        color-scheme: dark;
+        --bg-deep: #06070f;
+        --bg-mid: #0c0e22;
+        --bg-glow: #1a1746;
+        --ink-soft: rgba(220, 224, 255, 0.62);
+        --ink-mid: rgba(225, 230, 255, 0.82);
+        --ink-strong: #f4f5ff;
+        --accent-cool: #7dd3fc;
+        --accent-warm: #fbbf24;
+        --accent-hot: #fb7185;
+        --line: rgba(140, 160, 220, 0.12);
+      }
       * { box-sizing: border-box; margin: 0; padding: 0; }
+      html, body { overflow-x: hidden; }
       body {
-        background: #111;
+        position: relative;
+        min-height: 100dvh;
+        color: var(--ink-strong);
+        font-family: 'DM Mono', ui-monospace, monospace;
+        background:
+          radial-gradient(120% 80% at 50% -10%, var(--bg-glow) 0%, transparent 55%),
+          radial-gradient(80% 60% at 50% 110%, rgba(80, 30, 150, 0.4) 0%, transparent 60%),
+          linear-gradient(180deg, var(--bg-mid) 0%, var(--bg-deep) 100%);
+        background-attachment: fixed;
         display: flex;
         justify-content: center;
         align-items: flex-start;
-        min-height: 100dvh;
-        font-family: system-ui, sans-serif;
-        color: #fff;
-        padding: 8px;
+        padding: 12px 8px 32px;
+      }
+      body::before {
+        content: '';
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        background-image:
+          radial-gradient(circle at 18% 22%, rgba(125, 211, 252, 0.06) 0, transparent 38%),
+          radial-gradient(circle at 82% 76%, rgba(251, 113, 133, 0.05) 0, transparent 42%);
+        z-index: 0;
+      }
+      body::after {
+        content: '';
+        position: fixed;
+        inset: -2px;
+        pointer-events: none;
+        opacity: 0.35;
+        mix-blend-mode: overlay;
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.55  0 0 0 0 0.6  0 0 0 0 0.85  0 0 0 0.45 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+        z-index: 0;
       }
       #app {
+        position: relative;
+        z-index: 1;
         display: flex;
         flex-direction: column;
         align-items: center;
         width: 100%;
-        max-width: 500px;
+        max-width: 520px;
+        gap: 8px;
+      }
+      ::selection {
+        background: rgba(125, 211, 252, 0.35);
+        color: var(--ink-strong);
       }
     </style>
   </head>

--- a/src/tuning-console/console.ts
+++ b/src/tuning-console/console.ts
@@ -22,50 +22,77 @@ export interface TuningConsoleHandle {
 
 const STYLES = `
 .tc-panel {
-  background: #181828;
-  color: #e8e8f0;
-  border-left: 1px solid #333;
-  width: 320px;
+  background:
+    radial-gradient(120% 60% at 50% 0%, rgba(125, 211, 252, 0.07), transparent 60%),
+    linear-gradient(180deg, rgba(18, 20, 40, 0.96), rgba(8, 9, 22, 0.98));
+  color: var(--ink-strong, #f4f5ff);
+  border-left: 1px solid rgba(140, 160, 220, 0.12);
+  width: 340px;
   height: 100dvh;
   overflow-y: auto;
-  padding: 16px;
-  font-family: system-ui, sans-serif;
-  font-size: 13px;
+  padding: 22px 22px 32px;
+  font-family: 'DM Mono', ui-monospace, monospace;
+  font-size: 12px;
   display: none;
   flex-shrink: 0;
   position: fixed;
   top: 0;
   right: 0;
   z-index: 50;
-  box-shadow: -2px 0 12px rgba(0,0,0,0.5);
+  box-shadow: -20px 0 60px rgba(0,0,0,0.55);
+  backdrop-filter: blur(14px);
   box-sizing: border-box;
+  transform: translateX(8px);
+  opacity: 0;
+  transition: transform 280ms cubic-bezier(.2,.8,.3,1), opacity 220ms ease;
 }
 body[data-console-open] .tc-panel {
   display: block;
+  transform: translateX(0);
+  opacity: 1;
 }
+.tc-panel::-webkit-scrollbar { width: 6px; }
+.tc-panel::-webkit-scrollbar-thumb { background: rgba(125, 211, 252, 0.18); border-radius: 3px; }
 .tc-panel h2 {
-  font-size: 14px;
-  letter-spacing: 2px;
-  color: #888;
-  margin: 16px 0 8px;
+  font-family: 'Unbounded', system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  color: rgba(220, 224, 255, 0.42);
+  margin: 22px 0 12px;
   text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.tc-panel h2::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(140, 160, 220, 0.18), transparent);
 }
 .tc-panel h2:first-of-type { margin-top: 0; }
 .tc-slider, .tc-number {
   display: block;
-  margin: 8px 0;
+  margin: 10px 0;
 }
 .tc-slider-row {
   display: flex;
   justify-content: space-between;
-  font-size: 12px;
-  margin-bottom: 2px;
+  font-size: 11px;
+  margin-bottom: 4px;
+  align-items: baseline;
 }
-.tc-slider-label { color: #ccc; }
-.tc-slider-readout { color: #88c; font-variant-numeric: tabular-nums; }
+.tc-slider-label { color: rgba(225, 230, 255, 0.72); letter-spacing: 0.08em; }
+.tc-slider-readout {
+  color: var(--accent-cool, #7dd3fc);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
 .tc-slider input[type=range] {
   width: 100%;
-  accent-color: #88c;
+  accent-color: var(--accent-cool, #7dd3fc);
+  height: 4px;
 }
 .tc-number {
   display: flex;
@@ -74,84 +101,117 @@ body[data-console-open] .tc-panel {
   gap: 8px;
 }
 .tc-number input[type=number] {
-  background: #222;
-  color: #eee;
-  border: 1px solid #444;
-  border-radius: 4px;
-  padding: 4px 6px;
-  width: 80px;
+  background: rgba(8, 10, 22, 0.6);
+  color: var(--ink-strong, #f4f5ff);
+  border: 1px solid rgba(140, 160, 220, 0.18);
+  border-radius: 8px;
+  padding: 6px 10px;
+  width: 110px;
+  font-family: 'DM Mono', monospace;
   font-size: 12px;
+  outline: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+.tc-number input[type=number]:focus {
+  border-color: rgba(125, 211, 252, 0.55);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.12);
 }
 .tc-button {
-  background: #2a3050;
+  background: linear-gradient(180deg, rgba(40, 56, 110, 0.85), rgba(20, 30, 70, 0.85));
   color: #fff;
-  border: 1px solid #445;
-  border-radius: 4px;
-  padding: 6px 12px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  border-radius: 999px;
+  padding: 7px 14px;
   cursor: pointer;
-  font-size: 12px;
-  margin: 4px 4px 4px 0;
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 6px 6px 6px 0;
+  transition: all 160ms ease;
 }
-.tc-button:hover { background: #3a4060; }
+.tc-button:hover {
+  background: linear-gradient(180deg, rgba(60, 90, 170, 0.95), rgba(30, 50, 110, 0.95));
+  box-shadow: 0 6px 24px rgba(125, 211, 252, 0.18);
+  transform: translateY(-1px);
+}
 .tc-textarea {
   width: 100%;
   height: 160px;
-  background: #0e0e18;
-  color: #cfcfd8;
-  border: 1px solid #333;
-  border-radius: 4px;
-  padding: 6px;
-  font-family: ui-monospace, monospace;
+  background: rgba(4, 6, 16, 0.7);
+  color: rgba(220, 224, 255, 0.85);
+  border: 1px solid rgba(140, 160, 220, 0.18);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-family: 'DM Mono', monospace;
   font-size: 11px;
   resize: vertical;
   box-sizing: border-box;
+  outline: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
 }
-.tc-textarea.tc-error { border-color: #c0392b; }
-.tc-message { font-size: 11px; margin-top: 4px; min-height: 1em; }
-.tc-message.tc-error { color: #e57b7b; }
-.tc-message.tc-success { color: #7fc97f; }
+.tc-textarea:focus {
+  border-color: rgba(125, 211, 252, 0.45);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.1);
+}
+.tc-textarea.tc-error { border-color: rgba(255, 100, 120, 0.6); box-shadow: 0 0 0 3px rgba(255, 100, 120, 0.12); }
+.tc-message { font-size: 11px; margin-top: 6px; min-height: 1em; letter-spacing: 0.04em; }
+.tc-message.tc-error { color: #ff8a8a; }
+.tc-message.tc-success { color: #5ee2a0; }
 .tc-advanced-toggle {
   background: none;
   border: none;
-  color: #88c;
+  color: var(--accent-cool, #7dd3fc);
   cursor: pointer;
-  padding: 4px 0;
-  font-size: 12px;
-  text-decoration: underline;
+  padding: 6px 0;
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-top: 6px;
 }
+.tc-advanced-toggle:hover { color: #fff; }
 .tc-advanced { display: none; }
 .tc-advanced[data-open] { display: block; }
-.tc-percent { color: #666; font-size: 10px; margin-left: 6px; }
+.tc-percent { color: rgba(220, 224, 255, 0.4); font-size: 10px; margin-left: 8px; font-variant-numeric: tabular-nums; }
 .tc-warning {
-  background: #4a2a2a;
-  color: #ffb;
-  padding: 6px 8px;
-  border-radius: 4px;
+  background: rgba(110, 30, 30, 0.55);
+  color: #ffd2c2;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 120, 100, 0.35);
   font-size: 11px;
-  margin: 4px 0;
+  margin: 8px 0;
   display: none;
 }
 .tc-warning[data-show] { display: block; }
 .tc-header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 12px;
+  align-items: center;
+  margin-bottom: 18px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(140, 160, 220, 0.12);
 }
 .tc-title {
-  font-size: 16px;
-  letter-spacing: 4px;
-  font-weight: 700;
-  color: #eef;
+  font-family: 'Unbounded', system-ui, sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.36em;
+  font-weight: 800;
+  color: var(--ink-strong, #f4f5ff);
 }
 .tc-close {
-  background: none;
-  border: none;
-  color: #888;
-  font-size: 18px;
+  background: rgba(20, 24, 48, 0.6);
+  border: 1px solid rgba(140, 160, 220, 0.18);
+  color: rgba(220, 224, 255, 0.62);
+  font-size: 16px;
   cursor: pointer;
-  padding: 0 4px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  line-height: 1.2;
+  transition: all 160ms ease;
 }
+.tc-close:hover { color: #fff; border-color: rgba(255, 138, 138, 0.5); }
 `;
 
 let stylesInjected = false;

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -6,7 +6,7 @@ import {
   validateChainExtension,
   GameSession,
 } from '../game-session/index.js';
-import type { Cell, GameConfig, TileValue } from '../game-session/index.js';
+import type { Cell, GameConfig, TileValue, Board, GameEvent, GameState } from '../game-session/index.js';
 import {
   boardPixelWidth,
   boardPixelHeight,
@@ -14,164 +14,366 @@ import {
 } from './board.js';
 import { attachInput } from './input.js';
 import type { InputCallbacks } from './input.js';
-import { countRetiredTiles, createHud, flashConquest, updateChainPreview, updateHud } from './hud.js';
+import {
+  createHud, updateHud, updateChainPreview, flashBanner, clearGameOver,
+  countRetiredTiles, flashConquest,
+} from './hud.js';
 import { mountTuningConsole } from '../tuning-console/console.js';
+import { tileTheme } from './theme.js';
 import { PlaylogRecorder } from '../game-session/playlog.js';
 import { mountPlaylogControls } from './playlog-controls.js';
+import {
+  EffectQueue,
+  spawnTileSpawn,
+  spawnTilePop,
+  spawnFlash,
+  spawnParticleBurst,
+  spawnShockwave,
+  spawnScreenPulse,
+  spawnRetirementSweep,
+  spawnConquestConfetti,
+} from './effects.js';
 
 function injectStyles(): void {
   const style = document.createElement('style');
   style.textContent = `
-    .hud-top {
+    .hud-root {
+      width: 100%;
       display: flex;
-      gap: 24px;
-      justify-content: center;
+      flex-direction: column;
+      gap: 14px;
+      padding: 18px 4px 10px;
+    }
+    .hud-branding {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
       align-items: center;
-      padding: 12px 0 8px;
+      width: 100%;
+      gap: 12px;
+    }
+    .hud-toolbar {
+      display: flex;
+      gap: 8px;
+      justify-self: end;
+      align-items: center;
+    }
+    .hud-phase {
+      justify-self: center;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 14px;
+      border-radius: 999px;
+      font-family: 'DM Mono', monospace;
+      font-size: 11px;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      border: 1px solid var(--line);
+      background: rgba(20, 24, 48, 0.55);
+      color: var(--ink-mid);
+      transition: border-color 240ms ease, color 240ms ease, box-shadow 320ms ease, background 240ms ease, transform 240ms ease;
+    }
+    .hud-phase-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: currentColor;
+      box-shadow: 0 0 12px currentColor;
+      transition: background 240ms ease, box-shadow 240ms ease;
+    }
+    .hud-phase[data-phase="free-play"] {
+      color: #5ee2a0;
+      border-color: rgba(94, 226, 160, 0.4);
+      box-shadow: 0 0 18px rgba(94, 226, 160, 0.12);
+    }
+    .hud-phase[data-phase="cleanup"] {
+      color: #ffb573;
+      border-color: rgba(255, 181, 115, 0.45);
+      background: rgba(60, 30, 12, 0.5);
+      box-shadow: 0 0 22px rgba(255, 181, 115, 0.18);
+    }
+    .hud-phase[data-phase="conquest"] {
+      color: #ffe07a;
+      border-color: rgba(255, 224, 122, 0.7);
+      background: linear-gradient(180deg, rgba(80, 60, 0, 0.6), rgba(40, 20, 0, 0.6));
+      box-shadow: 0 0 30px rgba(255, 224, 122, 0.45), inset 0 0 18px rgba(255, 224, 122, 0.18);
+      animation: phase-conquest-pulse 1100ms ease-in-out infinite alternate;
+    }
+    @keyframes phase-conquest-pulse {
+      from { transform: scale(1); }
+      to   { transform: scale(1.04); }
+    }
+    .hud-playlog-download {
+      background: rgba(20, 24, 48, 0.6);
+      color: var(--ink-mid);
+      border: 1px solid var(--line);
+      backdrop-filter: blur(10px);
+      border-radius: 999px;
+      padding: 7px 14px;
+      cursor: pointer;
+      font-family: 'DM Mono', monospace;
+      font-size: 11px;
+      letter-spacing: 0.18em;
+      transition: all 160ms ease;
+    }
+    .hud-playlog-download:hover {
+      color: var(--ink-strong);
+      border-color: rgba(125, 211, 252, 0.5);
+      box-shadow: 0 0 24px rgba(125, 211, 252, 0.2);
+    }
+    .hud-mark {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+    }
+    .hud-mark-glyph {
+      font-family: 'Unbounded', system-ui, sans-serif;
+      font-size: 28px;
+      color: var(--accent-cool);
+      text-shadow: 0 0 22px rgba(125, 211, 252, 0.6);
+      transform: translateY(2px);
+    }
+    .hud-mark-word {
+      font-family: 'Unbounded', system-ui, sans-serif;
+      font-weight: 800;
+      font-size: 22px;
+      letter-spacing: 0.18em;
+      color: var(--ink-strong);
+    }
+    .hud-tuning-toggle {
+      background: rgba(20, 24, 48, 0.6);
+      color: var(--ink-mid);
+      border: 1px solid var(--line);
+      backdrop-filter: blur(10px);
+      border-radius: 999px;
+      padding: 7px 14px 7px 11px;
+      cursor: pointer;
+      font-family: 'DM Mono', monospace;
+      font-size: 11px;
+      letter-spacing: 0.18em;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      transition: all 160ms ease;
+    }
+    .hud-tuning-toggle:hover {
+      color: var(--ink-strong);
+      border-color: rgba(125, 211, 252, 0.5);
+      box-shadow: 0 0 24px rgba(125, 211, 252, 0.2);
+    }
+    .hud-tuning-icon { font-size: 14px; line-height: 1; }
+    .hud-stats {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
       width: 100%;
     }
     .hud-stat {
+      position: relative;
       display: flex;
       flex-direction: column;
-      align-items: center;
-      gap: 2px;
-      min-width: 64px;
+      align-items: flex-start;
+      gap: 4px;
+      padding: 12px 14px;
+      background: linear-gradient(180deg, rgba(18, 22, 44, 0.7), rgba(10, 12, 28, 0.55));
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      min-height: 64px;
+      min-width: 0;
+      overflow: hidden;
+      transition: border-color 220ms ease, box-shadow 220ms ease;
     }
+    .hud-stat::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: radial-gradient(60% 100% at 50% 0%, rgba(125, 211, 252, 0.08), transparent 70%);
+      opacity: 0;
+      transition: opacity 220ms ease;
+    }
+    .hud-stat--armed {
+      border-color: rgba(125, 211, 252, 0.45);
+      box-shadow: 0 0 28px rgba(125, 211, 252, 0.15), inset 0 0 18px rgba(125, 211, 252, 0.08);
+    }
+    .hud-stat--armed::before { opacity: 1; }
     .hud-label {
-      font-size: 10px;
-      letter-spacing: 2px;
-      color: #666;
-      font-weight: 600;
+      font-family: 'DM Mono', monospace;
+      font-size: 9px;
+      letter-spacing: 0.28em;
+      color: var(--ink-soft);
+      text-transform: uppercase;
     }
     .hud-value {
-      font-size: 22px;
+      font-family: 'Unbounded', system-ui, sans-serif;
       font-weight: 700;
-      color: #eee;
-    }
-    .hud-tuning-toggle {
-      background: #2a3050;
-      color: #fff;
-      border: 1px solid #445;
-      border-radius: 6px;
-      padding: 6px 10px;
-      cursor: pointer;
-      font-size: 18px;
+      font-size: 22px;
+      color: var(--ink-strong);
       line-height: 1;
+      transition: color 220ms ease, text-shadow 220ms ease, transform 220ms ease;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-variant-numeric: tabular-nums;
     }
-    .hud-tuning-toggle:hover { background: #3a4060; }
-    .hud-playlog-download {
-      background: #2a3050;
-      color: #fff;
-      border: 1px solid #445;
-      border-radius: 6px;
-      padding: 6px 10px;
-      cursor: pointer;
-      font-size: 12px;
-      line-height: 1;
+    .hud-value--big { font-size: 26px; }
+    .hud-value--accent { color: var(--accent-cool); }
+    .hud-value--mono {
+      font-family: 'DM Mono', monospace;
+      font-weight: 500;
+      font-size: 15px;
+      letter-spacing: 0.04em;
     }
-    .hud-playlog-download:hover { background: #3a4060; }
+    @keyframes hud-flash {
+      0%   { transform: translateY(-4px) scale(1.05); }
+      100% { transform: translateY(0)    scale(1);    }
+    }
+    @keyframes hud-flash-big {
+      0%   { transform: translateY(-6px) scale(1.18); filter: brightness(1.4); }
+      60%  { transform: translateY(0)    scale(1.05); filter: brightness(1.15); }
+      100% { transform: translateY(0)    scale(1);    filter: brightness(1);    }
+    }
+    .hud-value--flash { animation: hud-flash 280ms cubic-bezier(.2,.8,.3,1.4); }
+    .hud-value--big-flash { animation: hud-flash-big 720ms cubic-bezier(.2,.8,.3,1.4); }
+
+    .hud-banner {
+      width: 100%;
+      min-height: 24px;
+      text-align: center;
+      font-family: 'Unbounded', system-ui, sans-serif;
+      font-weight: 800;
+      font-size: 14px;
+      letter-spacing: 0.32em;
+      color: var(--accent-cool);
+      opacity: 0;
+      transform: translateY(-4px);
+      pointer-events: none;
+      transition: opacity 280ms ease, transform 280ms ease;
+    }
+    .hud-banner--show {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .board-frame {
+      position: relative;
+      padding: 14px;
+      border-radius: 22px;
+      background:
+        radial-gradient(120% 70% at 50% -20%, rgba(125,211,252,0.08), transparent 70%),
+        linear-gradient(180deg, rgba(20,24,48,0.85), rgba(10,12,28,0.75));
+      border: 1px solid var(--line);
+      box-shadow:
+        0 30px 80px rgba(0, 0, 0, 0.55),
+        0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+      width: 100%;
+      max-width: 520px;
+      display: flex;
+      justify-content: center;
+    }
     canvas {
       display: block;
       touch-action: none;
       cursor: crosshair;
+      filter: drop-shadow(0 8px 24px rgba(0,0,0,0.5));
     }
-    .game-over-overlay {
+
+    .game-over {
       position: fixed;
       inset: 0;
-      background: rgba(0,0,0,0.75);
+      background: radial-gradient(circle at 50% 40%, rgba(15, 8, 35, 0.78), rgba(2, 3, 10, 0.92));
+      backdrop-filter: blur(8px);
       display: flex;
       align-items: center;
       justify-content: center;
       z-index: 100;
+      opacity: 0;
+      transition: opacity 380ms ease;
     }
-    .game-over-overlay.hidden {
-      display: none;
-    }
-    .game-over-box {
-      background: #1a1a2e;
-      border: 2px solid #444;
-      border-radius: 16px;
-      padding: 32px 40px;
-      text-align: center;
+    .game-over--show { opacity: 1; }
+    .game-over.hidden { display: none; }
+    .game-over-card {
+      background: linear-gradient(180deg, rgba(28, 28, 60, 0.95), rgba(12, 14, 38, 0.95));
+      border: 1px solid rgba(255, 100, 120, 0.35);
+      box-shadow:
+        0 40px 120px rgba(0, 0, 0, 0.75),
+        0 0 80px rgba(255, 100, 120, 0.18);
+      border-radius: 20px;
+      padding: 36px 44px;
       display: flex;
       flex-direction: column;
-      gap: 16px;
+      gap: 18px;
+      align-items: center;
+      max-width: 380px;
+      width: calc(100% - 32px);
+      transform: translateY(20px) scale(0.96);
+      transition: transform 480ms cubic-bezier(.2,.9,.3,1.2);
+    }
+    .game-over--show .game-over-card { transform: translateY(0) scale(1); }
+    .game-over-eyebrow {
+      font-family: 'DM Mono', monospace;
+      font-size: 10px;
+      letter-spacing: 0.5em;
+      color: var(--ink-soft);
     }
     .game-over-title {
-      font-size: 28px;
+      font-family: 'Unbounded', system-ui, sans-serif;
       font-weight: 800;
-      letter-spacing: 4px;
-      color: #e74c3c;
+      font-size: 26px;
+      letter-spacing: 0.04em;
+      color: #ff8a8a;
+      text-align: center;
+      text-shadow: 0 0 30px rgba(255, 138, 138, 0.4);
     }
-    #game-over-stats {
-      color: #ccc;
-      font-size: 16px;
+    .game-over-stats {
+      width: 100%;
       display: flex;
       flex-direction: column;
-      gap: 6px;
+      gap: 10px;
+      padding: 14px 0;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
     }
-    #game-over-restart {
-      margin-top: 8px;
-      padding: 10px 24px;
-      background: #3a6fbf;
+    .game-over-stat {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+    .game-over-stat-k {
+      font-family: 'DM Mono', monospace;
+      font-size: 11px;
+      letter-spacing: 0.22em;
+      color: var(--ink-soft);
+      text-transform: uppercase;
+    }
+    .game-over-stat-v {
+      font-family: 'Unbounded', system-ui, sans-serif;
+      font-weight: 700;
+      font-size: 18px;
+      color: var(--ink-strong);
+    }
+    .game-over-cta {
+      margin-top: 4px;
+      padding: 12px 22px;
+      background: linear-gradient(180deg, #2c5acc, #1a3a90);
       color: #fff;
-      border: none;
-      border-radius: 8px;
-      font-size: 16px;
-      font-weight: 600;
-      cursor: pointer;
-    }
-    #game-over-restart:hover {
-      background: #4a7fa5;
-    }
-    .hud-phase {
-      font-size: 16px;
-      padding: 2px 10px;
+      border: 1px solid rgba(255,255,255,0.1);
       border-radius: 999px;
-      transition: background 0.25s ease, color 0.25s ease;
+      font-family: 'Unbounded', system-ui, sans-serif;
+      font-weight: 700;
+      font-size: 13px;
+      letter-spacing: 0.28em;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      box-shadow: 0 12px 32px rgba(44, 90, 204, 0.45), inset 0 1px 0 rgba(255,255,255,0.18);
+      transition: transform 180ms ease, box-shadow 220ms ease;
     }
-    .hud-phase[data-phase="free-play"] {
-      background: rgba(76, 175, 90, 0.2);
-      color: #6ddc8a;
-    }
-    .hud-phase[data-phase="cleanup"] {
-      background: rgba(245, 165, 36, 0.22);
-      color: #ffb049;
-    }
-    .hud-phase[data-phase="conquest"] {
-      background: linear-gradient(90deg, #ffd54a, #ff9d3d);
-      color: #1a1a2e;
-      animation: phase-pop 0.45s ease;
-    }
-    @keyframes phase-pop {
-      0% { transform: scale(0.85); }
-      60% { transform: scale(1.12); }
-      100% { transform: scale(1); }
-    }
-    .conquest-banner {
-      position: fixed;
-      top: 25%;
-      left: 50%;
-      transform: translate(-50%, -50%) scale(0.7);
-      background: linear-gradient(135deg, #ffd54a 0%, #ff9d3d 100%);
-      color: #1a1a2e;
-      padding: 16px 36px;
-      border-radius: 14px;
-      font-size: 28px;
-      font-weight: 800;
-      letter-spacing: 3px;
-      box-shadow: 0 12px 32px rgba(0,0,0,0.4);
-      pointer-events: none;
-      opacity: 0;
-      z-index: 90;
-      transition: opacity 0.25s ease, transform 0.4s cubic-bezier(0.18, 0.89, 0.32, 1.28);
-    }
-    .conquest-banner.hidden {
-      display: none;
-    }
-    .conquest-banner-active {
-      opacity: 1;
-      transform: translate(-50%, -50%) scale(1);
+    .game-over-cta:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 18px 40px rgba(44, 90, 204, 0.55), inset 0 1px 0 rgba(255,255,255,0.25);
     }
   `;
   document.head.appendChild(style);
@@ -185,24 +387,36 @@ function mount(): void {
 
   let session = new GameSession(DEFAULT_CONFIG);
 
+  // Track previous board for diffing (used to detect tier conquest)
+  let previousBoard: Board = session.getState().board;
+
+  const effects = new EffectQueue();
+
+  const hud = createHud(app);
+
+  const boardFrame = document.createElement('div');
+  boardFrame.className = 'board-frame';
+  app.appendChild(boardFrame);
+
   const canvas = document.createElement('canvas');
   function resizeCanvas(cfg: GameConfig): void {
     const W = boardPixelWidth(cfg.gridCols);
     const H = boardPixelHeight(cfg.gridRows);
-    canvas.width = W;
-    canvas.height = H;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = W * dpr;
+    canvas.height = H * dpr;
     canvas.style.width = `min(100%, ${W}px)`;
     canvas.style.aspectRatio = `${W} / ${H}`;
     canvas.style.height = 'auto';
+    const c = canvas.getContext('2d');
+    if (c !== null) c.setTransform(dpr, 0, 0, dpr, 0, 0);
   }
   resizeCanvas(session.getState().config);
+  boardFrame.appendChild(canvas);
 
   const ctxOrNull = canvas.getContext('2d');
   if (ctxOrNull === null) return;
   const ctx = ctxOrNull;
-
-  const hud = createHud(app);
-  app.appendChild(canvas);
 
   let currentChain: readonly Cell[] = [];
   let previewValue: TileValue | null = null;
@@ -238,8 +452,9 @@ function mount(): void {
     return result;
   }
 
-  function render(): void {
+  function renderFrame(now: number): void {
     const state = session.getState();
+    effects.prune(now);
     renderBoard(ctx, {
       board: state.board,
       chain: currentChain,
@@ -247,9 +462,18 @@ function mount(): void {
       validExtensions,
       rows: state.config.gridRows,
       cols: state.config.gridCols,
+      effects,
+      now,
     });
-    updateHud(hud, state);
   }
+
+  // RAF loop runs continuously — animations are time-based.
+  let rafId = 0;
+  function loop(now: number): void {
+    renderFrame(now);
+    rafId = requestAnimationFrame(loop);
+  }
+  rafId = requestAnimationFrame(loop);
 
   function makeInputCallbacks(): InputCallbacks {
     return {
@@ -267,7 +491,6 @@ function mount(): void {
           catch { previewValue = null; }
         }
         updateChainPreview(hud, previewValue);
-        render();
       },
       onChainCommit(chain: readonly Cell[]): void {
         const state = session.getState();
@@ -278,7 +501,6 @@ function mount(): void {
           session.dispatch({ kind: 'commit-chain', chain });
         } else {
           updateChainPreview(hud, null);
-          render();
         }
       },
       onChainCancel(): void {
@@ -286,38 +508,105 @@ function mount(): void {
         previewValue = null;
         validExtensions = new Set();
         updateChainPreview(hud, null);
-        render();
       },
     };
   }
 
-  // Track retired-tile count across renders so we can detect the cleanup→
-  // free-play transition (= conquest) and flash the celebration.
-  let prevRetiredCount = countRetiredTiles(session.getState().board);
+  function handleKernelEvents(state: GameState, kernelEvents: readonly GameEvent[]): void {
+    const W = boardPixelWidth(state.config.gridCols);
+    const H = boardPixelHeight(state.config.gridRows);
 
-  function makeListener(): () => void {
-    return (): void => {
-      const retiredCount = countRetiredTiles(session.getState().board);
-      if (prevRetiredCount > 0 && retiredCount === 0) flashConquest(hud);
-      prevRetiredCount = retiredCount;
-      render();
-    };
+    for (const e of kernelEvents) {
+      if (e.kind === 'chain-resolved') {
+        // Burst at each source tile (skip last — that's the result cell)
+        for (let i = 0; i < e.chain.length - 1; i++) {
+          const src = e.chain[i];
+          if (src === undefined) continue;
+          const sourceTile = previousBoard[src.row]?.[src.col];
+          const v = sourceTile?.value ?? e.resultValue;
+          effects.push(spawnParticleBurst(src, v, 8));
+        }
+        // Result tile: pop + flash + shockwave + screen pulse
+        effects.push(spawnTilePop(e.resultCell, e.resultValue));
+        effects.push(spawnFlash(e.resultCell, e.resultValue));
+        effects.push(spawnShockwave(e.resultCell, e.resultValue));
+        // Big merges (length 4+) get a screen pulse
+        if (e.chain.length >= 4) effects.push(spawnScreenPulse(e.resultValue));
+        // Banner for milestone result values
+        if (e.resultValue >= 256) {
+          const theme = tileTheme(e.resultValue);
+          flashBanner(hud, e.resultValue >= 1024 ? `LEGENDARY · ${e.resultValue}` : `${e.resultValue} forged`, { color: theme.aura, glow: theme.glow });
+        }
+      } else if (e.kind === 'tiles-spawned') {
+        for (const sp of e.spawned) {
+          effects.push(spawnTileSpawn(sp.cell, sp.value));
+        }
+      } else if (e.kind === 'retirement-fired') {
+        effects.push(spawnRetirementSweep(e.retiredTier));
+        effects.push(spawnScreenPulse(e.retiredTier));
+        const theme = tileTheme(e.retiredTier);
+        flashBanner(hud, `${e.retiredTier} retired · cleanup`, { color: '#ff8a8a', glow: theme.glow });
+      }
+      // game-over event: handled by updateHud → showGameOver
+    }
+
+    // Tier conquest detection: tiers that had retired tiles previously and now don't
+    detectAndCelebrateConquest(state, W, H);
+
+    previousBoard = state.board;
   }
 
-  let unsubscribe = session.on(makeListener());
+  const conquestedTiers = new Set<TileValue>();
+  let prevRetiredCount = countRetiredTiles(session.getState().board);
+
+  function detectAndCelebrateConquest(state: GameState, W: number, H: number): void {
+    const prevRetiredTiers = new Set<TileValue>();
+    const currRetiredTiers = new Set<TileValue>();
+    for (const row of previousBoard) for (const t of row) if (t.retired && t.value > 0) prevRetiredTiers.add(t.value);
+    for (const row of state.board)   for (const t of row) if (t.retired && t.value > 0) currRetiredTiers.add(t.value);
+    for (const tier of prevRetiredTiers) {
+      if (!currRetiredTiers.has(tier) && !conquestedTiers.has(tier)) {
+        conquestedTiers.add(tier);
+        effects.push(spawnConquestConfetti(W, H, tier));
+        effects.push(spawnScreenPulse(tier));
+        const theme = tileTheme(tier);
+        flashBanner(hud, `CONQUEST · ${tier}`, { color: theme.aura, glow: theme.glow });
+      }
+    }
+
+    // Phase chip flash: triggered when ALL retired tiles get cleared
+    // (a "fully clean" board moment, distinct from per-tier celebration above).
+    const retiredCount = countRetiredTiles(state.board);
+    if (prevRetiredCount > 0 && retiredCount === 0) flashConquest(hud);
+    prevRetiredCount = retiredCount;
+  }
+
+  let unsubscribe = session.on(event => {
+    handleKernelEvents(event.state, event.kernelEvents);
+    updateHud(hud, event.state);
+  });
   let detach = attachInput(canvas, session.getState().config.gridRows, session.getState().config.gridCols, makeInputCallbacks());
+
+  // Per-turn play recorder. Survives session restarts via attachSession.
   const playlog = new PlaylogRecorder(session);
+  mountPlaylogControls(hud.toolbar, playlog);
 
   function rewireSession(newSession: GameSession): void {
     unsubscribe();
     detach();
+    effects.clear();
+    conquestedTiers.clear();
     session = newSession;
+    previousBoard = session.getState().board;
+    prevRetiredCount = countRetiredTiles(session.getState().board);
     const cfg = session.getState().config;
     resizeCanvas(cfg);
-    prevRetiredCount = countRetiredTiles(session.getState().board);
-    unsubscribe = session.on(makeListener());
+    unsubscribe = session.on(event => {
+      handleKernelEvents(event.state, event.kernelEvents);
+      updateHud(hud, event.state);
+    });
     detach = attachInput(canvas, cfg.gridRows, cfg.gridCols, makeInputCallbacks());
-    playlog.attachSession(session);
+    playlog.attachSession(newSession);
   }
 
   const tuning = mountTuningConsole({
@@ -326,13 +615,11 @@ function mount(): void {
     onRequestNewGame(cfg: GameConfig): void {
       const newSession = new GameSession(cfg);
       rewireSession(newSession);
-      hud.gameOver.classList.add('hidden');
+      clearGameOver(hud);
       tuning.rebindSession(newSession);
-      render();
+      updateHud(hud, newSession.getState());
     },
   });
-
-  mountPlaylogControls(hud.tuningToggle.parentElement ?? app, playlog);
 
   hud.tuningToggle.addEventListener('click', () => {
     if (document.body.hasAttribute('data-console-open')) {
@@ -345,16 +632,19 @@ function mount(): void {
   const restartBtn = document.getElementById('game-over-restart');
   if (restartBtn !== null) {
     restartBtn.addEventListener('click', () => {
-      hud.gameOver.classList.add('hidden');
+      clearGameOver(hud);
       const currentCfg = session.getState().config;
       const newSession = new GameSession(currentCfg);
       rewireSession(newSession);
       tuning.rebindSession(newSession);
-      render();
+      updateHud(hud, newSession.getState());
     });
   }
 
-  render();
+  updateHud(hud, session.getState());
+
+  // Cleanup on unload (defensive)
+  window.addEventListener('beforeunload', () => { cancelAnimationFrame(rafId); });
 }
 
 mount();

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -1,230 +1,417 @@
 import type { Board, Cell, TileValue } from '../game-session/index.js';
+import {
+  TILE, GAP, RADIUS,
+  tileOriginX, tileOriginY,
+  boardPixelWidth, boardPixelHeight,
+  pixelToCell, roundRectPath,
+} from './geometry.js';
+import {
+  tileTheme, formatTileValue, fitFontSize,
+  EMPTY_CELL_FILL, EMPTY_CELL_BORDER,
+  BOARD_VIGNETTE_INNER, BOARD_VIGNETTE_OUTER,
+  RETIRED_CUT, RETIRED_FILM,
+  VALID_NEXT_GLOW,
+  CHAIN_TRAIL_HEAD, CHAIN_TRAIL_TAIL,
+  FONT_DISPLAY,
+} from './theme.js';
+import { renderEffect, sampleTileAnim, tileCenter } from './effects.js';
+import type { EffectQueue } from './effects.js';
 
-export const TILE = 76;
-export const GAP = 4;
-export const RADIUS = 8;
-
-function tileOffset(index: number): number {
-  return index * (TILE + GAP);
-}
-
-export function boardPixelWidth(cols: number): number {
-  return cols * TILE + (cols - 1) * GAP;
-}
-
-export function boardPixelHeight(rows: number): number {
-  return rows * TILE + (rows - 1) * GAP;
-}
-
-// Nearest-center hit detection: always returns the tile whose center is closest.
-// This makes diagonal movement reliable — gaps are never "dead zones."
-export function pixelToCell(
-  x: number,
-  y: number,
-  rows: number,
-  cols: number,
-): Cell | null {
-  if (rows === 0 || cols === 0) return null;
-  let best: Cell | null = null;
-  let bestDist = Infinity;
-  for (let r = 0; r < rows; r++) {
-    for (let c = 0; c < cols; c++) {
-      const cx = tileOffset(c) + TILE / 2;
-      const cy = tileOffset(r) + TILE / 2;
-      const dist = (x - cx) * (x - cx) + (y - cy) * (y - cy);
-      if (dist < bestDist) {
-        bestDist = dist;
-        best = { row: r as Cell['row'], col: c as Cell['col'] };
-      }
-    }
-  }
-  return best;
-}
-
-// Hue wheel: low values → cool blues, higher → warm reds/golds
-const TILE_COLORS: Readonly<Partial<Record<TileValue, string>>> = {
-  2:    '#4a7fa5',
-  4:    '#3a6fbf',
-  8:    '#27ae60',
-  16:   '#8bc34a',
-  32:   '#f1c40f',
-  64:   '#e67e22',
-  128:  '#e74c3c',
-  256:  '#c0392b',
-  512:  '#9b59b6',
-  1024: '#6c3483',
-  2048: '#f39c12',
-  4096: '#d4ac0d',
-  8192: '#f5cba7',
-};
-
-function tileColor(value: TileValue): string {
-  return TILE_COLORS[value] ?? '#555';
-}
-
-function textColor(value: TileValue): string {
-  // Dark text on bright tiles
-  if (value === 32 || value === 16 || value === 2048 || value === 4096 || value === 8192) {
-    return '#222';
-  }
-  return '#fff';
-}
-
-function fontSize(value: TileValue): number {
-  if (value >= 1000) return 18;
-  if (value >= 100) return 22;
-  return 26;
-}
-
-function roundRect(
-  ctx: CanvasRenderingContext2D,
-  x: number, y: number,
-  w: number, h: number,
-  r: number,
-): void {
-  ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + w - r, y);
-  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-  ctx.lineTo(x + w, y + h - r);
-  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-  ctx.lineTo(x + r, y + h);
-  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
-  ctx.closePath();
-}
+export { TILE, GAP, RADIUS, boardPixelWidth, boardPixelHeight, pixelToCell };
 
 export interface RenderState {
   board: Board;
   chain: readonly Cell[];
   previewValue: TileValue | null;
-  /** Cells that could validly extend the current chain (highlighted for player). */
   validExtensions: ReadonlySet<string>;
   rows: number;
   cols: number;
+  effects: EffectQueue;
+  now: number;
 }
 
 export function renderBoard(ctx: CanvasRenderingContext2D, s: RenderState): void {
-  const { board, chain, previewValue, validExtensions, rows, cols } = s;
+  const { board, chain, previewValue, validExtensions, rows, cols, effects, now } = s;
+  const W = boardPixelWidth(cols);
+  const H = boardPixelHeight(rows);
+  ctx.clearRect(0, 0, W, H);
+
+  drawBoardBackdrop(ctx, W, H);
 
   const chainSet = new Set(chain.map(c => `${c.row},${c.col}`));
   const lastCell = chain[chain.length - 1];
+  const hasActiveChain = chain.length > 0;
+  const activeEffects = effects.active();
 
-  ctx.clearRect(0, 0, boardPixelWidth(cols), boardPixelHeight(rows));
-
+  // Pass 1: empty cells (drawn behind everything else)
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
       const tile = board[r]?.[c];
-      if (tile === undefined) continue;
+      if (tile === undefined || tile.value !== 0) continue;
+      drawEmptyCell(ctx, c, r);
+    }
+  }
 
-      const x = tileOffset(c);
-      const y = tileOffset(r);
+  // Pass 2: tile auras (so they layer below tile bodies but above empty cells)
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const tile = board[r]?.[c];
+      if (tile === undefined || tile.value === 0) continue;
       const key = `${r},${c}`;
       const inChain = chainSet.has(key);
       const isLast = lastCell !== undefined && lastCell.row === r && lastCell.col === c;
       const isValidNext = validExtensions.has(key);
-
-      if (tile.value === 0) {
-        // Empty cell
-        ctx.fillStyle = '#1a1a2e';
-        roundRect(ctx, x, y, TILE, TILE, RADIUS);
-        ctx.fill();
-        continue;
-      }
-
-      // Tile background — dim tiles that can't extend the active chain
-      const hasActiveChain = chainSet.size > 0;
-      const color = tileColor(tile.value);
-      let fillColor = color;
-      if (inChain) fillColor = lighten(color, 0.35);
-      else if (hasActiveChain && !isValidNext) fillColor = darken(color, 0.5);
-      else if (tile.retired) fillColor = darken(color, 0.35);
-      ctx.fillStyle = fillColor;
-      roundRect(ctx, x, y, TILE, TILE, RADIUS);
-      ctx.fill();
-
-      if (tile.retired) {
-        ctx.save();
-        ctx.strokeStyle = 'rgba(255,255,255,0.35)';
-        ctx.lineWidth = 2;
-        ctx.beginPath();
-        ctx.moveTo(x + 14, y + TILE - 14);
-        ctx.lineTo(x + TILE - 14, y + 14);
-        ctx.moveTo(x + 24, y + TILE - 10);
-        ctx.lineTo(x + TILE - 10, y + 24);
-        ctx.stroke();
-        ctx.restore();
-      }
-
-      // Chain highlight border; green pulse on valid-next tiles
-      if (inChain) {
-        ctx.strokeStyle = isLast ? '#ffffff' : 'rgba(255,255,255,0.6)';
-        ctx.lineWidth = isLast ? 3 : 2;
-        roundRect(ctx, x + 1, y + 1, TILE - 2, TILE - 2, RADIUS - 1);
-        ctx.stroke();
-      } else if (isValidNext) {
-        ctx.strokeStyle = 'rgba(120,255,120,0.8)';
-        ctx.lineWidth = 2;
-        roundRect(ctx, x + 1, y + 1, TILE - 2, TILE - 2, RADIUS - 1);
-        ctx.stroke();
-      }
-
-      // Value text
-      ctx.fillStyle = textColor(tile.value);
-      ctx.font = `bold ${fontSize(tile.value)}px system-ui, sans-serif`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(String(tile.value), x + TILE / 2, y + TILE / 2);
-
-      // Preview result badge on last chain cell
-      if (isLast && previewValue !== null) {
-        const bx = x + TILE - 28;
-        const by = y + 4;
-        ctx.fillStyle = 'rgba(0,0,0,0.75)';
-        roundRect(ctx, bx, by, 28, 20, 4);
-        ctx.fill();
-        ctx.fillStyle = '#fff';
-        ctx.font = 'bold 11px system-ui, sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(`→${previewValue}`, bx + 14, by + 10);
-      }
+      const anim = sampleTileAnim(activeEffects, { row: r as Cell['row'], col: c as Cell['col'] }, now);
+      drawTileAura(ctx, c, r, tile.value, {
+        inChain, isLast, isValidNext, hasActiveChain,
+        anim,
+        retired: tile.retired,
+        now,
+      });
     }
   }
 
-  // Draw chain path lines
-  if (chain.length >= 2) {
-    ctx.strokeStyle = 'rgba(255,255,255,0.4)';
-    ctx.lineWidth = 3;
+  // Pass 3: tile bodies + text
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const tile = board[r]?.[c];
+      if (tile === undefined || tile.value === 0) continue;
+      const key = `${r},${c}`;
+      const inChain = chainSet.has(key);
+      const isLast = lastCell !== undefined && lastCell.row === r && lastCell.col === c;
+      const isValidNext = validExtensions.has(key);
+      const anim = sampleTileAnim(activeEffects, { row: r as Cell['row'], col: c as Cell['col'] }, now);
+      drawTileBody(ctx, c, r, tile.value, tile.retired, {
+        inChain, isLast, isValidNext, hasActiveChain,
+        anim,
+        now,
+      });
+    }
+  }
+
+  // Pass 4: chain trail above tiles
+  if (chain.length >= 2) drawChainTrail(ctx, chain, now);
+
+  // Pass 5: preview badge above everything
+  if (lastCell !== undefined && previewValue !== null && chain.length >= 2) {
+    drawPreviewBadge(ctx, lastCell, previewValue, now);
+  }
+
+  // Pass 6: effects (particles, flashes, confetti, sweeps)
+  for (const e of activeEffects) {
+    renderEffect(e, { ctx, now, boardW: W, boardH: H });
+  }
+}
+
+function drawBoardBackdrop(ctx: CanvasRenderingContext2D, W: number, H: number): void {
+  // Subtle radial vignette behind tiles
+  const grad = ctx.createRadialGradient(W / 2, H / 2, 0, W / 2, H / 2, Math.max(W, H) * 0.7);
+  grad.addColorStop(0, BOARD_VIGNETTE_INNER);
+  grad.addColorStop(1, BOARD_VIGNETTE_OUTER);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, W, H);
+}
+
+function drawEmptyCell(ctx: CanvasRenderingContext2D, col: number, row: number): void {
+  const x = tileOriginX(col);
+  const y = tileOriginY(row);
+  ctx.save();
+  roundRectPath(ctx, x, y, TILE, TILE, RADIUS);
+  ctx.fillStyle = EMPTY_CELL_FILL;
+  ctx.fill();
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = EMPTY_CELL_BORDER;
+  ctx.stroke();
+  ctx.restore();
+}
+
+interface DrawOpts {
+  inChain: boolean;
+  isLast: boolean;
+  isValidNext: boolean;
+  hasActiveChain: boolean;
+  anim: ReturnType<typeof sampleTileAnim>;
+  now: number;
+}
+
+function drawTileAura(
+  ctx: CanvasRenderingContext2D,
+  col: number, row: number,
+  value: TileValue,
+  opts: DrawOpts & { retired: boolean },
+): void {
+  const x = tileOriginX(col);
+  const y = tileOriginY(row);
+  const cx = x + TILE / 2;
+  const cy = y + TILE / 2 + opts.anim.yOffset;
+  const theme = tileTheme(value);
+
+  // Base aura — quiet for non-chain tiles, brighter for chain & last cell & valid next
+  let auraStrength = 0.32;
+  let auraRadius = TILE * 0.85;
+  if (opts.inChain) { auraStrength = 0.85; auraRadius = TILE * 1.05; }
+  if (opts.isLast) { auraStrength = 1.05; auraRadius = TILE * 1.2; }
+  if (opts.isValidNext) {
+    const pulse = 0.5 + 0.5 * Math.sin(opts.now / 220);
+    auraStrength = 0.7 + pulse * 0.35;
+    auraRadius = TILE * (1.0 + pulse * 0.1);
+  }
+  // Dim non-eligible tiles when chain is active
+  if (opts.hasActiveChain && !opts.inChain && !opts.isValidNext) auraStrength *= 0.45;
+  if (opts.retired) auraStrength *= 0.6;
+  auraStrength += opts.anim.glowBoost;
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  const grad = ctx.createRadialGradient(cx, cy, TILE * 0.15, cx, cy, auraRadius);
+  grad.addColorStop(0, theme.glow);
+  grad.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = grad;
+  ctx.globalAlpha = Math.min(1, auraStrength);
+  ctx.fillRect(cx - auraRadius, cy - auraRadius, auraRadius * 2, auraRadius * 2);
+  ctx.restore();
+}
+
+function drawTileBody(
+  ctx: CanvasRenderingContext2D,
+  col: number, row: number,
+  value: TileValue,
+  retired: boolean,
+  opts: DrawOpts,
+): void {
+  const x = tileOriginX(col);
+  const y = tileOriginY(row);
+  const cx = x + TILE / 2;
+  const cy = y + TILE / 2 + opts.anim.yOffset;
+  const theme = tileTheme(value);
+  const scale = opts.anim.scale;
+
+  ctx.save();
+  ctx.globalAlpha = opts.anim.alpha;
+  ctx.translate(cx, cy);
+  ctx.scale(scale, scale);
+  ctx.translate(-TILE / 2, -TILE / 2);
+
+  // Inactive dimming when chain active (lighten non-eligible)
+  let bodyAlpha = 1;
+  if (opts.hasActiveChain && !opts.inChain && !opts.isValidNext) bodyAlpha = 0.42;
+
+  // Layered fill: vertical gradient from shine → fill
+  const grad = ctx.createLinearGradient(0, 0, 0, TILE);
+  grad.addColorStop(0, mixColor(theme.shine, theme.fill, 0.55));
+  grad.addColorStop(0.55, theme.fill);
+  grad.addColorStop(1, mixColor(theme.fill, '#000000', 0.35));
+
+  ctx.save();
+  ctx.globalAlpha = bodyAlpha;
+  roundRectPath(ctx, 0, 0, TILE, TILE, RADIUS);
+  ctx.fillStyle = grad;
+  ctx.fill();
+
+  // Inner top highlight — narrow band of shine across the top
+  ctx.save();
+  roundRectPath(ctx, 0, 0, TILE, TILE, RADIUS);
+  ctx.clip();
+  const shineGrad = ctx.createLinearGradient(0, 0, 0, TILE * 0.45);
+  shineGrad.addColorStop(0, hexToRgba(theme.shine, 0.45));
+  shineGrad.addColorStop(1, hexToRgba(theme.shine, 0));
+  ctx.fillStyle = shineGrad;
+  ctx.fillRect(0, 0, TILE, TILE * 0.45);
+  ctx.restore();
+
+  // Subtle inner shadow at bottom
+  ctx.save();
+  roundRectPath(ctx, 0, 0, TILE, TILE, RADIUS);
+  ctx.clip();
+  const shadowGrad = ctx.createLinearGradient(0, TILE * 0.5, 0, TILE);
+  shadowGrad.addColorStop(0, 'rgba(0,0,0,0)');
+  shadowGrad.addColorStop(1, 'rgba(0,0,0,0.45)');
+  ctx.fillStyle = shadowGrad;
+  ctx.fillRect(0, TILE * 0.5, TILE, TILE * 0.5);
+  ctx.restore();
+
+  // Hairline outer border
+  roundRectPath(ctx, 0.5, 0.5, TILE - 1, TILE - 1, RADIUS);
+  ctx.strokeStyle = hexToRgba(theme.shine, 0.35);
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.restore();
+
+  // Retired film + cuts
+  if (retired) {
+    ctx.save();
+    roundRectPath(ctx, 0, 0, TILE, TILE, RADIUS);
+    ctx.fillStyle = RETIRED_FILM;
+    ctx.fill();
+
+    // Cross-hatch warning marks
+    ctx.strokeStyle = RETIRED_CUT;
+    ctx.lineWidth = 2.5;
     ctx.lineCap = 'round';
-    ctx.lineJoin = 'round';
+    const inset = 14;
     ctx.beginPath();
-    for (let i = 0; i < chain.length; i++) {
-      const cell = chain[i];
-      if (cell === undefined) continue;
-      const cx = tileOffset(cell.col) + TILE / 2;
-      const cy = tileOffset(cell.row) + TILE / 2;
-      if (i === 0) ctx.moveTo(cx, cy);
-      else ctx.lineTo(cx, cy);
-    }
+    ctx.moveTo(inset, inset);
+    ctx.lineTo(TILE - inset, TILE - inset);
+    ctx.moveTo(TILE - inset, inset);
+    ctx.lineTo(inset, TILE - inset);
     ctx.stroke();
+    ctx.restore();
   }
+
+  // Chain selection ring
+  if (opts.inChain) {
+    const ringStrength = opts.isLast ? 1 : 0.65;
+    ctx.save();
+    roundRectPath(ctx, 1.5, 1.5, TILE - 3, TILE - 3, RADIUS - 1);
+    ctx.strokeStyle = `rgba(255,255,255,${ringStrength})`;
+    ctx.lineWidth = opts.isLast ? 3 : 2;
+    ctx.stroke();
+    ctx.restore();
+  } else if (opts.isValidNext) {
+    const pulse = 0.55 + 0.45 * Math.sin(opts.now / 200);
+    ctx.save();
+    roundRectPath(ctx, 1.5, 1.5, TILE - 3, TILE - 3, RADIUS - 1);
+    ctx.strokeStyle = VALID_NEXT_GLOW;
+    ctx.lineWidth = 2;
+    ctx.globalAlpha = 0.55 + pulse * 0.4;
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Value text — auto-fit to tile width using compact-format
+  const label = formatTileValue(value);
+  const fz = fitFontSize(ctx, label, TILE - 16, FONT_DISPLAY);
+  ctx.fillStyle = theme.text;
+  ctx.font = `700 ${fz}px ${FONT_DISPLAY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.shadowColor = retired ? 'rgba(0,0,0,0.7)' : 'rgba(0,0,0,0.35)';
+  ctx.shadowBlur = 4;
+  ctx.shadowOffsetY = 1;
+  ctx.fillText(label, TILE / 2, TILE / 2 + 1);
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetY = 0;
+
+  ctx.restore();
 }
 
-function darken(hex: string, amount: number): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  const clamp = (v: number): number => Math.max(0, Math.round(v * (1 - amount)));
-  return `rgb(${clamp(r)},${clamp(g)},${clamp(b)})`;
+function drawChainTrail(
+  ctx: CanvasRenderingContext2D,
+  chain: readonly Cell[],
+  now: number,
+): void {
+  ctx.save();
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.globalCompositeOperation = 'lighter';
+
+  // Outer soft trail
+  ctx.strokeStyle = CHAIN_TRAIL_TAIL;
+  ctx.lineWidth = 14;
+  ctx.beginPath();
+  for (let i = 0; i < chain.length; i++) {
+    const cell = chain[i];
+    if (cell === undefined) continue;
+    const { cx, cy } = tileCenter(cell);
+    if (i === 0) ctx.moveTo(cx, cy);
+    else ctx.lineTo(cx, cy);
+  }
+  ctx.stroke();
+
+  // Inner bright core with animated dash
+  const dashOffset = (now / 30) % 24;
+  ctx.strokeStyle = CHAIN_TRAIL_HEAD;
+  ctx.lineWidth = 4;
+  ctx.setLineDash([10, 14]);
+  ctx.lineDashOffset = -dashOffset;
+  ctx.globalAlpha = 0.85;
+  ctx.beginPath();
+  for (let i = 0; i < chain.length; i++) {
+    const cell = chain[i];
+    if (cell === undefined) continue;
+    const { cx, cy } = tileCenter(cell);
+    if (i === 0) ctx.moveTo(cx, cy);
+    else ctx.lineTo(cx, cy);
+  }
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Bright nodes at each chain cell
+  for (let i = 0; i < chain.length; i++) {
+    const cell = chain[i];
+    if (cell === undefined) continue;
+    const { cx, cy } = tileCenter(cell);
+    const r = i === chain.length - 1 ? 5 : 3;
+    const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r * 4);
+    grad.addColorStop(0, 'rgba(255,255,255,1)');
+    grad.addColorStop(1, 'rgba(255,255,255,0)');
+    ctx.fillStyle = grad;
+    ctx.fillRect(cx - r * 4, cy - r * 4, r * 8, r * 8);
+  }
+
+  ctx.restore();
 }
 
-// Simple brightness boost without external deps
-function lighten(hex: string, amount: number): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  const clamp = (v: number): number => Math.min(255, Math.round(v + (255 - v) * amount));
-  return `rgb(${clamp(r)},${clamp(g)},${clamp(b)})`;
+function drawPreviewBadge(
+  ctx: CanvasRenderingContext2D,
+  cell: Cell,
+  value: TileValue,
+  now: number,
+): void {
+  const x = tileOriginX(cell.col);
+  const y = tileOriginY(cell.row);
+  const theme = tileTheme(value);
+  const text = `→ ${formatTileValue(value)}`;
+  ctx.save();
+  ctx.font = `700 12px ${FONT_DISPLAY}`;
+  const metrics = ctx.measureText(text);
+  const padX = 8;
+  const w = Math.ceil(metrics.width) + padX * 2;
+  const h = 22;
+  const bx = x + TILE - w + 6;
+  const by = y - h / 2;
+  const bob = Math.sin(now / 200) * 1.5;
+
+  // Soft drop shadow
+  ctx.save();
+  ctx.shadowColor = theme.glow;
+  ctx.shadowBlur = 16;
+  roundRectPath(ctx, bx, by + bob, w, h, 11);
+  ctx.fillStyle = '#0a0c1a';
+  ctx.fill();
+  ctx.restore();
+
+  // Border outline using tier glow color
+  roundRectPath(ctx, bx, by + bob, w, h, 11);
+  ctx.strokeStyle = theme.aura;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+
+  ctx.fillStyle = theme.aura;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, bx + w / 2, by + h / 2 + bob + 1);
+  ctx.restore();
+}
+
+// ─── Color utilities ─────────────────────────────────────────────────────
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return { r, g, b };
+}
+
+function hexToRgba(hex: string, a: number): string {
+  const { r, g, b } = hexToRgb(hex);
+  return `rgba(${r},${g},${b},${a})`;
+}
+
+function mixColor(a: string, b: string, t: number): string {
+  const ca = hexToRgb(a);
+  const cb = hexToRgb(b);
+  const mix = (x: number, y: number): number => Math.round(x + (y - x) * t);
+  return `rgb(${mix(ca.r, cb.r)},${mix(ca.g, cb.g)},${mix(ca.b, cb.b)})`;
 }

--- a/src/ui/effects.ts
+++ b/src/ui/effects.ts
@@ -1,0 +1,349 @@
+import type { Cell, TileValue } from '../game-session/index.js';
+import { EASE, DURATION, tileTheme } from './theme.js';
+import { TILE, GAP } from './geometry.js';
+
+export type Effect =
+  | { type: 'tile-spawn'; cell: Cell; value: TileValue; start: number; duration: number }
+  | { type: 'tile-pop'; cell: Cell; value: TileValue; start: number; duration: number }
+  | { type: 'particle-burst'; cx: number; cy: number; color: string; count: number; start: number; duration: number; spread: number }
+  | { type: 'shockwave'; cx: number; cy: number; color: string; maxRadius: number; start: number; duration: number }
+  | { type: 'flash'; rect: Rect; color: string; start: number; duration: number }
+  | { type: 'screen-pulse'; color: string; start: number; duration: number }
+  | { type: 'retirement-sweep'; tier: TileValue; start: number; duration: number }
+  | { type: 'conquest-confetti'; tier: TileValue; start: number; duration: number; pieces: ConfettiPiece[] };
+
+export interface Rect { x: number; y: number; w: number; h: number }
+
+export interface ConfettiPiece {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  rot: number;
+  vrot: number;
+  color: string;
+  size: number;
+}
+
+export function tileCenter(cell: Cell): { cx: number; cy: number } {
+  const cx = cell.col * (TILE + GAP) + TILE / 2;
+  const cy = cell.row * (TILE + GAP) + TILE / 2;
+  return { cx, cy };
+}
+
+export class EffectQueue {
+  private effects: Effect[] = [];
+
+  push(effect: Effect): void {
+    this.effects.push(effect);
+  }
+
+  prune(now: number): void {
+    this.effects = this.effects.filter(e => now - e.start < e.duration);
+  }
+
+  active(): readonly Effect[] {
+    return this.effects;
+  }
+
+  hasActive(): boolean {
+    return this.effects.length > 0;
+  }
+
+  clear(): void {
+    this.effects = [];
+  }
+}
+
+export function spawnParticleBurst(cell: Cell, value: TileValue, count = 14): Effect {
+  const { cx, cy } = tileCenter(cell);
+  return {
+    type: 'particle-burst',
+    cx, cy,
+    color: tileTheme(value).aura,
+    count,
+    spread: TILE * 1.4,
+    start: performance.now(),
+    duration: DURATION.burst,
+  };
+}
+
+export function spawnShockwave(cell: Cell, value: TileValue): Effect {
+  const { cx, cy } = tileCenter(cell);
+  return {
+    type: 'shockwave',
+    cx, cy,
+    color: tileTheme(value).aura,
+    maxRadius: TILE * 1.9,
+    start: performance.now(),
+    duration: DURATION.burst,
+  };
+}
+
+export function spawnFlash(cell: Cell, value: TileValue): Effect {
+  const { cx, cy } = tileCenter(cell);
+  return {
+    type: 'flash',
+    rect: { x: cx - TILE / 2 - 6, y: cy - TILE / 2 - 6, w: TILE + 12, h: TILE + 12 },
+    color: tileTheme(value).shine,
+    start: performance.now(),
+    duration: DURATION.flash,
+  };
+}
+
+export function spawnTileSpawn(cell: Cell, value: TileValue): Effect {
+  return {
+    type: 'tile-spawn',
+    cell,
+    value,
+    start: performance.now(),
+    duration: DURATION.spawn,
+  };
+}
+
+export function spawnTilePop(cell: Cell, value: TileValue): Effect {
+  return {
+    type: 'tile-pop',
+    cell,
+    value,
+    start: performance.now(),
+    duration: DURATION.pop,
+  };
+}
+
+export function spawnScreenPulse(value: TileValue): Effect {
+  return {
+    type: 'screen-pulse',
+    color: tileTheme(value).aura,
+    start: performance.now(),
+    duration: DURATION.shimmer,
+  };
+}
+
+export function spawnRetirementSweep(tier: TileValue): Effect {
+  return {
+    type: 'retirement-sweep',
+    tier,
+    start: performance.now(),
+    duration: DURATION.retirementPulse,
+  };
+}
+
+export function spawnConquestConfetti(boardW: number, boardH: number, tier: TileValue): Effect {
+  const theme = tileTheme(tier);
+  const palette = [theme.aura, theme.shine, '#fff7d6', '#ffffff', theme.fill];
+  const pieces: ConfettiPiece[] = [];
+  const count = 80;
+  for (let i = 0; i < count; i++) {
+    const angle = -Math.PI / 2 + (Math.random() - 0.5) * Math.PI * 0.8;
+    const speed = 320 + Math.random() * 460;
+    pieces.push({
+      x: boardW / 2 + (Math.random() - 0.5) * boardW * 0.6,
+      y: boardH * 0.55,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      rot: Math.random() * Math.PI * 2,
+      vrot: (Math.random() - 0.5) * 12,
+      color: palette[Math.floor(Math.random() * palette.length)] ?? '#fff',
+      size: 4 + Math.random() * 8,
+    });
+  }
+  return {
+    type: 'conquest-confetti',
+    tier,
+    start: performance.now(),
+    duration: DURATION.conquest,
+    pieces,
+  };
+}
+
+// ─── Effect rendering ─────────────────────────────────────────────────────
+
+export interface EffectRenderCtx {
+  ctx: CanvasRenderingContext2D;
+  now: number;
+  boardW: number;
+  boardH: number;
+}
+
+export function renderEffect(effect: Effect, r: EffectRenderCtx): void {
+  const t = (r.now - effect.start) / effect.duration;
+  if (t < 0 || t > 1) return;
+
+  switch (effect.type) {
+    case 'particle-burst':
+      renderParticleBurst(effect, t, r.ctx);
+      break;
+    case 'shockwave':
+      renderShockwave(effect, t, r.ctx);
+      break;
+    case 'flash':
+      renderFlash(effect, t, r.ctx);
+      break;
+    case 'screen-pulse':
+      renderScreenPulse(effect, t, r);
+      break;
+    case 'retirement-sweep':
+      renderRetirementSweep(effect, t, r);
+      break;
+    case 'conquest-confetti':
+      renderConfetti(effect, t, r);
+      break;
+    case 'tile-spawn':
+    case 'tile-pop':
+      // Handled inline in board renderer (transform during tile draw)
+      break;
+  }
+}
+
+function renderParticleBurst(effect: Extract<Effect, { type: 'particle-burst' }>, t: number, ctx: CanvasRenderingContext2D): void {
+  const eased = EASE.outCubic(t);
+  const fade = 1 - t;
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  for (let i = 0; i < effect.count; i++) {
+    const angle = (i / effect.count) * Math.PI * 2 + effect.start * 0.01;
+    const dist = effect.spread * eased;
+    const x = effect.cx + Math.cos(angle) * dist;
+    const y = effect.cy + Math.sin(angle) * dist;
+    const r = 4 * (1 - t * 0.5);
+    const grad = ctx.createRadialGradient(x, y, 0, x, y, r * 3);
+    grad.addColorStop(0, effect.color);
+    grad.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = grad;
+    ctx.globalAlpha = fade;
+    ctx.beginPath();
+    ctx.arc(x, y, r * 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function renderShockwave(effect: Extract<Effect, { type: 'shockwave' }>, t: number, ctx: CanvasRenderingContext2D): void {
+  const eased = EASE.outQuint(t);
+  const r = effect.maxRadius * eased;
+  const fade = 1 - t;
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  ctx.strokeStyle = effect.color;
+  ctx.globalAlpha = fade * 0.85;
+  ctx.lineWidth = 4 * (1 - t * 0.6);
+  ctx.beginPath();
+  ctx.arc(effect.cx, effect.cy, r, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function renderFlash(effect: Extract<Effect, { type: 'flash' }>, t: number, ctx: CanvasRenderingContext2D): void {
+  const fade = 1 - t;
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  const cx = effect.rect.x + effect.rect.w / 2;
+  const cy = effect.rect.y + effect.rect.h / 2;
+  const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, effect.rect.w * 0.85);
+  grad.addColorStop(0, effect.color);
+  grad.addColorStop(0.6, 'rgba(255,255,255,0.05)');
+  grad.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = grad;
+  ctx.globalAlpha = fade;
+  ctx.fillRect(effect.rect.x - 30, effect.rect.y - 30, effect.rect.w + 60, effect.rect.h + 60);
+  ctx.restore();
+}
+
+function renderScreenPulse(effect: Extract<Effect, { type: 'screen-pulse' }>, t: number, r: EffectRenderCtx): void {
+  const fade = 1 - t;
+  const ctx = r.ctx;
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  const grad = ctx.createRadialGradient(r.boardW / 2, r.boardH / 2, 0, r.boardW / 2, r.boardH / 2, Math.max(r.boardW, r.boardH));
+  grad.addColorStop(0, effect.color);
+  grad.addColorStop(0.4, 'rgba(255,255,255,0.04)');
+  grad.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = grad;
+  ctx.globalAlpha = fade * 0.5;
+  ctx.fillRect(0, 0, r.boardW, r.boardH);
+  ctx.restore();
+}
+
+function renderRetirementSweep(effect: Extract<Effect, { type: 'retirement-sweep' }>, t: number, r: EffectRenderCtx): void {
+  const ctx = r.ctx;
+  const theme = tileTheme(effect.tier);
+  const fade = 1 - EASE.outCubic(t);
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  const grad = ctx.createLinearGradient(0, 0, 0, r.boardH);
+  grad.addColorStop(0, 'rgba(0,0,0,0)');
+  grad.addColorStop(0.5, theme.aura);
+  grad.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = grad;
+  ctx.globalAlpha = fade * 0.35;
+  ctx.fillRect(0, 0, r.boardW, r.boardH);
+  ctx.restore();
+}
+
+function renderConfetti(effect: Extract<Effect, { type: 'conquest-confetti' }>, t: number, r: EffectRenderCtx): void {
+  const ctx = r.ctx;
+  const elapsed = (r.now - effect.start) / 1000;
+  const gravity = 720;
+  const fade = t > 0.7 ? 1 - (t - 0.7) / 0.3 : 1;
+  ctx.save();
+  for (const p of effect.pieces) {
+    const x = p.x + p.vx * elapsed;
+    const y = p.y + p.vy * elapsed + 0.5 * gravity * elapsed * elapsed;
+    if (y > r.boardH + 40) continue;
+    const rot = p.rot + p.vrot * elapsed;
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(rot);
+    ctx.globalAlpha = fade;
+    ctx.fillStyle = p.color;
+    ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+    ctx.restore();
+  }
+  ctx.restore();
+}
+
+// ─── Tile-anim helpers (sampled by board renderer per-frame) ─────────────
+
+export interface TileAnimState {
+  scale: number;
+  alpha: number;
+  yOffset: number;
+  glowBoost: number;
+}
+
+export function sampleTileAnim(
+  effects: readonly Effect[],
+  cell: Cell,
+  now: number,
+): TileAnimState {
+  let scale = 1;
+  let alpha = 1;
+  let yOffset = 0;
+  let glowBoost = 0;
+  for (const e of effects) {
+    if (e.type !== 'tile-spawn' && e.type !== 'tile-pop') continue;
+    if (e.cell.row !== cell.row || e.cell.col !== cell.col) continue;
+    const t = (now - e.start) / e.duration;
+    if (t < 0 || t > 1) continue;
+    if (e.type === 'tile-spawn') {
+      const eased = EASE.outBack(t, 1.4);
+      scale = 0.4 + eased * 0.6;
+      alpha = Math.min(1, t * 2);
+      yOffset = -TILE * 0.7 * (1 - eased);
+      glowBoost = (1 - t) * 0.6;
+    } else {
+      // tile-pop: punch up then settle
+      const peak = 0.35;
+      if (t < peak) {
+        scale = 1 + (t / peak) * 0.18;
+        glowBoost = t / peak;
+      } else {
+        const k = (t - peak) / (1 - peak);
+        scale = 1.18 - EASE.outCubic(k) * 0.18;
+        glowBoost = (1 - k) * 0.9;
+      }
+    }
+  }
+  return { scale, alpha, yOffset, glowBoost };
+}

--- a/src/ui/geometry.ts
+++ b/src/ui/geometry.ts
@@ -1,0 +1,64 @@
+import type { Cell } from '../game-session/index.js';
+
+export const TILE = 76;
+export const GAP = 6;
+export const RADIUS = 14;
+
+export function tileOriginX(col: number): number {
+  return col * (TILE + GAP);
+}
+
+export function tileOriginY(row: number): number {
+  return row * (TILE + GAP);
+}
+
+export function boardPixelWidth(cols: number): number {
+  return cols * TILE + (cols - 1) * GAP;
+}
+
+export function boardPixelHeight(rows: number): number {
+  return rows * TILE + (rows - 1) * GAP;
+}
+
+export function pixelToCell(
+  x: number,
+  y: number,
+  rows: number,
+  cols: number,
+): Cell | null {
+  if (rows === 0 || cols === 0) return null;
+  let best: Cell | null = null;
+  let bestDist = Infinity;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const cx = tileOriginX(c) + TILE / 2;
+      const cy = tileOriginY(r) + TILE / 2;
+      const d = (x - cx) * (x - cx) + (y - cy) * (y - cy);
+      if (d < bestDist) {
+        bestDist = d;
+        best = { row: r as Cell['row'], col: c as Cell['col'] };
+      }
+    }
+  }
+  return best;
+}
+
+export function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number, y: number,
+  w: number, h: number,
+  r: number,
+): void {
+  const rr = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.lineTo(x + w - rr, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + rr);
+  ctx.lineTo(x + w, y + h - rr);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - rr, y + h);
+  ctx.lineTo(x + rr, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - rr);
+  ctx.lineTo(x, y + rr);
+  ctx.quadraticCurveTo(x, y, x + rr, y);
+  ctx.closePath();
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,83 +1,116 @@
-import type { Board, GameState } from '../game-session/index.js';
+import type { Board, GameState, TileValue } from '../game-session/index.js';
+import { tileTheme, formatTileValue } from './theme.js';
 
 export type LifecyclePhase = 'free-play' | 'cleanup' | 'conquest';
 
 export interface HudElements {
+  root: HTMLElement;
+  title: HTMLElement;
   turn: HTMLElement;
-  phase: HTMLElement;
   maxTile: HTMLElement;
   spawnPool: HTMLElement;
   chainValue: HTMLElement;
-  conquestBanner: HTMLElement;
+  chainStat: HTMLElement;
+  phase: HTMLElement;
+  toolbar: HTMLElement;
   gameOver: HTMLElement;
   tuningToggle: HTMLButtonElement;
+  banner: HTMLElement;
 }
 
+interface HudCache {
+  turn: number;
+  max: TileValue;
+  pool: string;
+  chain: number | null;
+}
+
+const cache = new WeakMap<HudElements, HudCache>();
+
 export function createHud(container: HTMLElement): HudElements {
-  const topBar = document.createElement('div');
-  topBar.className = 'hud-top';
+  const root = document.createElement('header');
+  root.className = 'hud-root';
 
-  const turnEl = document.createElement('div');
-  turnEl.className = 'hud-stat';
-  turnEl.innerHTML = '<span class="hud-label">TURN</span><span class="hud-value" id="hud-turn">0</span>';
-
-  const phaseEl = document.createElement('div');
-  phaseEl.className = 'hud-stat';
-  phaseEl.innerHTML = '<span class="hud-label">PHASE</span><span class="hud-value hud-phase" id="hud-phase" data-phase="free-play">Free Play</span>';
-
-  const maxTileEl = document.createElement('div');
-  maxTileEl.className = 'hud-stat';
-  maxTileEl.innerHTML = '<span class="hud-label">BEST</span><span class="hud-value" id="hud-max">—</span>';
-
-  const spawnPoolEl = document.createElement('div');
-  spawnPoolEl.className = 'hud-stat';
-  spawnPoolEl.innerHTML = '<span class="hud-label">POOL</span><span class="hud-value" id="hud-pool">2–256</span>';
-
-  const chainValueEl = document.createElement('div');
-  chainValueEl.className = 'hud-stat';
-  chainValueEl.innerHTML = '<span class="hud-label">CHAIN</span><span class="hud-value" id="hud-chain">—</span>';
-
-  const tuningToggle = document.createElement('button');
-  tuningToggle.type = 'button';
-  tuningToggle.className = 'hud-tuning-toggle';
-  tuningToggle.setAttribute('aria-label', 'Toggle tuning panel');
-  tuningToggle.textContent = '⚙';
-
-  topBar.appendChild(turnEl);
-  topBar.appendChild(chainValueEl);
-  topBar.appendChild(phaseEl);
-  topBar.appendChild(maxTileEl);
-  topBar.appendChild(spawnPoolEl);
-  topBar.appendChild(tuningToggle);
-  container.appendChild(topBar);
-
-  const conquestBannerEl = document.createElement('div');
-  conquestBannerEl.className = 'conquest-banner hidden';
-  conquestBannerEl.id = 'conquest-banner';
-  conquestBannerEl.textContent = '🎉 TIER CONQUERED';
-  container.appendChild(conquestBannerEl);
-
-  const gameOverEl = document.createElement('div');
-  gameOverEl.className = 'game-over-overlay hidden';
-  gameOverEl.innerHTML = `
-    <div class="game-over-box">
-      <div class="game-over-title">GAME OVER</div>
-      <div id="game-over-stats"></div>
-      <button id="game-over-restart">Play Again</button>
+  const branding = document.createElement('div');
+  branding.className = 'hud-branding';
+  branding.innerHTML = `
+    <div class="hud-mark">
+      <span class="hud-mark-glyph">⌬</span>
+      <span class="hud-mark-word">CHAIN</span>
+    </div>
+    <div class="hud-phase" id="hud-phase" data-phase="free-play">
+      <span class="hud-phase-dot" aria-hidden="true"></span>
+      <span class="hud-phase-label">Free Play</span>
+    </div>
+    <div class="hud-toolbar">
+      <button type="button" class="hud-tuning-toggle" aria-label="Toggle tuning panel">
+        <span class="hud-tuning-icon">⚙</span>
+        <span class="hud-tuning-label">TUNING</span>
+      </button>
     </div>
   `;
-  container.appendChild(gameOverEl);
+  root.appendChild(branding);
 
-  return {
-    turn: document.getElementById('hud-turn') as HTMLElement,
-    phase: document.getElementById('hud-phase') as HTMLElement,
-    maxTile: document.getElementById('hud-max') as HTMLElement,
-    spawnPool: document.getElementById('hud-pool') as HTMLElement,
-    chainValue: document.getElementById('hud-chain') as HTMLElement,
-    conquestBanner: conquestBannerEl,
-    gameOver: gameOverEl,
-    tuningToggle,
+  const stats = document.createElement('div');
+  stats.className = 'hud-stats';
+  stats.innerHTML = `
+    <div class="hud-stat" data-stat="turn">
+      <span class="hud-label">turn</span>
+      <span class="hud-value" id="hud-turn">0</span>
+    </div>
+    <div class="hud-stat" data-stat="chain" id="hud-chain-stat">
+      <span class="hud-label">chain</span>
+      <span class="hud-value hud-value--accent" id="hud-chain">—</span>
+    </div>
+    <div class="hud-stat" data-stat="max">
+      <span class="hud-label">best tile</span>
+      <span class="hud-value hud-value--big" id="hud-max">—</span>
+    </div>
+    <div class="hud-stat" data-stat="pool">
+      <span class="hud-label">pool</span>
+      <span class="hud-value hud-value--mono" id="hud-pool">2 / 256</span>
+    </div>
+  `;
+  root.appendChild(stats);
+
+  container.appendChild(root);
+
+  const banner = document.createElement('div');
+  banner.className = 'hud-banner';
+  banner.setAttribute('aria-live', 'polite');
+  container.appendChild(banner);
+
+  const gameOver = document.createElement('div');
+  gameOver.className = 'game-over hidden';
+  gameOver.innerHTML = `
+    <div class="game-over-card">
+      <div class="game-over-eyebrow">RUN COMPLETE</div>
+      <div class="game-over-title">no chain remains</div>
+      <div class="game-over-stats" id="game-over-stats"></div>
+      <button id="game-over-restart" class="game-over-cta">
+        <span>BEGIN ANEW</span>
+        <span aria-hidden="true">→</span>
+      </button>
+    </div>
+  `;
+  container.appendChild(gameOver);
+
+  const elements: HudElements = {
+    root,
+    title: branding.querySelector('.hud-mark') as HTMLElement,
+    turn: stats.querySelector('#hud-turn') as HTMLElement,
+    maxTile: stats.querySelector('#hud-max') as HTMLElement,
+    spawnPool: stats.querySelector('#hud-pool') as HTMLElement,
+    chainValue: stats.querySelector('#hud-chain') as HTMLElement,
+    chainStat: stats.querySelector('#hud-chain-stat') as HTMLElement,
+    phase: branding.querySelector('#hud-phase') as HTMLElement,
+    toolbar: branding.querySelector('.hud-toolbar') as HTMLElement,
+    gameOver,
+    tuningToggle: branding.querySelector('.hud-tuning-toggle') as HTMLButtonElement,
+    banner,
   };
+  cache.set(elements, { turn: 0, max: 0, pool: '', chain: null });
+  return elements;
 }
 
 export function countRetiredTiles(board: Board): number {
@@ -94,48 +127,120 @@ export function lifecyclePhase(state: GameState): 'free-play' | 'cleanup' {
   return countRetiredTiles(state.board) > 0 ? 'cleanup' : 'free-play';
 }
 
-export function updateHud(hud: HudElements, state: GameState): void {
-  hud.turn.textContent = String(state.turn);
-  hud.maxTile.textContent = state.maxTileEver === 0 ? '—' : String(state.maxTileEver);
-  hud.spawnPool.textContent = `${state.spawnPoolMin}–${state.spawnPoolMax}`;
+const PHASE_LABEL: Record<LifecyclePhase, string> = {
+  'free-play': 'Free Play',
+  'cleanup': 'Cleanup',
+  'conquest': '🎉 Conquest',
+};
 
-  // Phase indicator. Conquest is a transient flash; the steady-state values
-  // are free-play / cleanup. setPhase() handles the transient externally.
-  const phase = lifecyclePhase(state);
+function setPhase(hud: HudElements, phase: LifecyclePhase): void {
+  if (hud.phase.dataset.phase === phase) return;
+  hud.phase.dataset.phase = phase;
+  const labelEl = hud.phase.querySelector('.hud-phase-label');
+  if (labelEl !== null) labelEl.textContent = PHASE_LABEL[phase];
+}
+
+/**
+ * Flash the conquest pill. Auto-reverts to free-play after duration.
+ * The full-screen confetti is handled separately via EffectQueue.
+ */
+export function flashConquest(hud: HudElements, durationMs = 2200): void {
+  setPhase(hud, 'conquest');
+  window.setTimeout(() => { setPhase(hud, 'free-play'); }, durationMs);
+}
+
+export function updateHud(hud: HudElements, state: GameState): void {
+  const prev = cache.get(hud) ?? { turn: 0, max: 0 as TileValue, pool: '', chain: null as number | null };
+
+  // Phase indicator. Conquest is a transient state; only update when not
+  // currently flashing it.
   if (hud.phase.dataset.phase !== 'conquest') {
-    hud.phase.dataset.phase = phase;
-    hud.phase.textContent = phase === 'cleanup' ? 'Cleanup' : 'Free Play';
+    setPhase(hud, lifecyclePhase(state));
   }
 
-  if (state.phase === 'game-over') {
-    const statsEl = document.getElementById('game-over-stats');
-    if (statsEl !== null) {
-      statsEl.innerHTML = `
-        <div>Turns: <strong>${state.turn}</strong></div>
-        <div>Best tile: <strong>${state.maxTileEver}</strong></div>
-      `;
+  if (state.turn !== prev.turn) {
+    hud.turn.textContent = String(state.turn);
+    flashStat(hud.turn);
+  }
+
+  if (state.maxTileEver !== prev.max) {
+    const old = prev.max;
+    hud.maxTile.textContent = state.maxTileEver === 0 ? '—' : formatTileValue(state.maxTileEver);
+    hud.maxTile.title = state.maxTileEver === 0 ? '' : String(state.maxTileEver);
+    if (state.maxTileEver > 0) {
+      const theme = tileTheme(state.maxTileEver);
+      hud.maxTile.style.color = theme.aura;
+      hud.maxTile.style.textShadow = `0 0 18px ${theme.glow}`;
     }
-    hud.gameOver.classList.remove('hidden');
+    if (state.maxTileEver > old) flashStat(hud.maxTile, true);
+  }
+
+  const poolText = `${formatTileValue(state.spawnPoolMin)} / ${formatTileValue(state.spawnPoolMax)}`;
+  hud.spawnPool.title = `${state.spawnPoolMin} → ${state.spawnPoolMax}`;
+  if (poolText !== prev.pool) {
+    hud.spawnPool.textContent = poolText;
+    flashStat(hud.spawnPool);
+  }
+
+  cache.set(hud, { turn: state.turn, max: state.maxTileEver, pool: poolText, chain: prev.chain });
+
+  if (state.phase === 'game-over') {
+    showGameOver(hud, state);
   }
 }
 
 export function updateChainPreview(hud: HudElements, value: number | null): void {
-  hud.chainValue.textContent = value !== null ? String(value) : '—';
+  const prev = cache.get(hud) ?? { turn: 0, max: 0 as TileValue, pool: '', chain: null as number | null };
+  if (prev.chain === value) return;
+  hud.chainValue.textContent = value !== null ? formatTileValue(value) : '—';
+  hud.chainValue.title = value !== null ? String(value) : '';
+  if (value !== null && value > 0) {
+    const theme = tileTheme(value);
+    hud.chainValue.style.color = theme.aura;
+    hud.chainValue.style.textShadow = `0 0 14px ${theme.glow}`;
+    hud.chainStat.classList.add('hud-stat--armed');
+  } else {
+    hud.chainValue.style.color = '';
+    hud.chainValue.style.textShadow = '';
+    hud.chainStat.classList.remove('hud-stat--armed');
+  }
+  cache.set(hud, { ...prev, chain: value });
 }
 
-// Flash the conquest celebration. Auto-reverts to free-play after duration.
-// Idempotent: calling while already in conquest extends the duration.
-export function flashConquest(hud: HudElements, durationMs = 2200): void {
-  hud.phase.dataset.phase = 'conquest';
-  hud.phase.textContent = '🎉 Conquest!';
+export function flashBanner(hud: HudElements, text: string, theme?: { color: string; glow: string }): void {
+  hud.banner.textContent = text;
+  hud.banner.classList.remove('hud-banner--show');
+  void hud.banner.offsetWidth;
+  hud.banner.classList.add('hud-banner--show');
+  if (theme !== undefined) {
+    hud.banner.style.color = theme.color;
+    hud.banner.style.textShadow = `0 0 22px ${theme.glow}`;
+  }
+  window.setTimeout(() => { hud.banner.classList.remove('hud-banner--show'); }, 2200);
+}
 
-  hud.conquestBanner.classList.remove('hidden');
-  hud.conquestBanner.classList.add('conquest-banner-active');
+export function clearGameOver(hud: HudElements): void {
+  hud.gameOver.classList.add('hidden');
+  hud.gameOver.classList.remove('game-over--show');
+}
 
-  window.setTimeout(() => {
-    hud.conquestBanner.classList.remove('conquest-banner-active');
-    hud.conquestBanner.classList.add('hidden');
-    hud.phase.dataset.phase = 'free-play';
-    hud.phase.textContent = 'Free Play';
-  }, durationMs);
+function showGameOver(hud: HudElements, state: GameState): void {
+  const statsEl = hud.gameOver.querySelector('#game-over-stats');
+  if (statsEl !== null) {
+    statsEl.innerHTML = `
+      <div class="game-over-stat"><span class="game-over-stat-k">turns</span><span class="game-over-stat-v">${state.turn}</span></div>
+      <div class="game-over-stat"><span class="game-over-stat-k">best tile</span><span class="game-over-stat-v" title="${state.maxTileEver}">${formatTileValue(state.maxTileEver)}</span></div>
+      <div class="game-over-stat"><span class="game-over-stat-k">pool reached</span><span class="game-over-stat-v" title="${state.spawnPoolMin} / ${state.spawnPoolMax}">${formatTileValue(state.spawnPoolMin)} / ${formatTileValue(state.spawnPoolMax)}</span></div>
+    `;
+  }
+  hud.gameOver.classList.remove('hidden');
+  // Force reflow then add show class for transition
+  void hud.gameOver.offsetWidth;
+  hud.gameOver.classList.add('game-over--show');
+}
+
+function flashStat(el: HTMLElement, big = false): void {
+  el.classList.remove('hud-value--flash', 'hud-value--big-flash');
+  void el.offsetWidth;
+  el.classList.add(big ? 'hud-value--big-flash' : 'hud-value--flash');
 }

--- a/src/ui/input.ts
+++ b/src/ui/input.ts
@@ -26,8 +26,11 @@ export function attachInput(
 
   function getCell(e: PointerEvent): Cell | null {
     const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
+    const dpr = window.devicePixelRatio || 1;
+    // canvas.width is in device pixels (W * dpr); rect.width is CSS pixels.
+    // We want coords in the ctx space (CSS pixels post-setTransform), so divide out dpr.
+    const scaleX = (canvas.width / rect.width) / dpr;
+    const scaleY = (canvas.height / rect.height) / dpr;
     const x = (e.clientX - rect.left) * scaleX;
     const y = (e.clientY - rect.top) * scaleY;
     return pixelToCell(x, y, rows, cols);

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,0 +1,143 @@
+import type { TileValue } from '../game-session/index.js';
+
+export const FONT_DISPLAY = "'Unbounded', 'Inter', system-ui, sans-serif";
+export const FONT_MONO = "'DM Mono', 'JetBrains Mono', ui-monospace, monospace";
+
+export interface TileTheme {
+  readonly fill: string;
+  readonly shine: string;
+  readonly glow: string;
+  readonly text: string;
+  readonly aura: string;
+}
+
+const TIER_THEMES: Readonly<Partial<Record<TileValue, TileTheme>>> = {
+  2:    { fill: '#3b6ea5', shine: '#7eb6e8', glow: 'rgba(126,182,232,0.55)', text: '#f3f9ff', aura: '#7eb6e8' },
+  4:    { fill: '#2c4dab', shine: '#6e89f0', glow: 'rgba(110,137,240,0.55)', text: '#f4f6ff', aura: '#6e89f0' },
+  8:    { fill: '#1c8f56', shine: '#5ee2a0', glow: 'rgba(94,226,160,0.55)',  text: '#f0fff5', aura: '#5ee2a0' },
+  16:   { fill: '#83c63a', shine: '#d4f291', glow: 'rgba(212,242,145,0.6)',  text: '#1c2200', aura: '#cfee8c' },
+  32:   { fill: '#e8b500', shine: '#fff09e', glow: 'rgba(255,224,90,0.7)',   text: '#241a00', aura: '#ffe05a' },
+  64:   { fill: '#e07520', shine: '#ffb573', glow: 'rgba(255,160,80,0.7)',   text: '#fff7ee', aura: '#ffa050' },
+  128:  { fill: '#d63b3a', shine: '#ff8a86', glow: 'rgba(255,90,80,0.75)',   text: '#fff5f4', aura: '#ff5a50' },
+  256:  { fill: '#b32325', shine: '#ff5b6c', glow: 'rgba(255,75,90,0.8)',    text: '#fff2f3', aura: '#ff4b5a' },
+  512:  { fill: '#8a3fb0', shine: '#cf83ee', glow: 'rgba(207,131,238,0.75)', text: '#faf3ff', aura: '#cf83ee' },
+  1024: { fill: '#5a1f7a', shine: '#a866d6', glow: 'rgba(168,102,214,0.85)', text: '#f7eeff', aura: '#a866d6' },
+  2048: { fill: '#e89a08', shine: '#ffd86b', glow: 'rgba(255,200,60,0.95)',  text: '#241a00', aura: '#ffc83c' },
+  4096: { fill: '#c79006', shine: '#ffe079', glow: 'rgba(255,205,80,0.95)',  text: '#241a00', aura: '#ffcd50' },
+  8192: { fill: '#dfb787', shine: '#fff2dd', glow: 'rgba(255,235,200,1)',    text: '#1c1408', aura: '#fff2dd' },
+};
+
+export const EMPTY_CELL_FILL = 'rgba(18, 22, 38, 0.55)';
+export const EMPTY_CELL_BORDER = 'rgba(110, 130, 180, 0.08)';
+export const BOARD_VIGNETTE_INNER = 'rgba(40, 50, 90, 0.18)';
+export const BOARD_VIGNETTE_OUTER = 'rgba(0, 0, 0, 0)';
+export const RETIRED_CUT = 'rgba(255, 90, 90, 0.85)';
+export const RETIRED_FILM = 'rgba(8, 10, 22, 0.55)';
+export const VALID_NEXT_GLOW = 'rgba(180, 255, 200, 0.95)';
+export const CHAIN_TRAIL_HEAD = 'rgba(255, 255, 255, 1)';
+export const CHAIN_TRAIL_TAIL = 'rgba(180, 220, 255, 0.15)';
+
+// Procedural palette for high tiers (>8192). Cycles hue, brightness ramps deeper
+// so successive tier conquests feel distinct without inventing 30+ hand-tuned colors.
+function highTierTheme(value: TileValue): TileTheme {
+  const log = Math.log2(value);
+  // Past 8192 (2^13) we cycle hue every ~6 tiers and rotate through 4 distinct families.
+  const tierIndex = Math.floor(log) - 13;
+  const family = tierIndex % 4;
+  const hue = (tierIndex * 47) % 360;
+  const sat = 70;
+  const light = 52 - Math.min(20, tierIndex * 1.6);
+  const fillH = hue;
+  const shineH = (hue + 18) % 360;
+  const fill = `hsl(${fillH}, ${sat}%, ${Math.max(28, light)}%)`;
+  const shine = `hsl(${shineH}, ${sat}%, ${Math.min(78, light + 30)}%)`;
+  const aura = `hsl(${shineH}, ${sat}%, ${Math.min(72, light + 22)}%)`;
+  const glow = `hsla(${shineH}, ${sat}%, ${Math.min(72, light + 22)}%, 0.7)`;
+  const text = family === 0 || family === 2 ? '#0c0814' : '#fff7e8';
+  return { fill, shine, glow, text, aura };
+}
+
+export function tileTheme(value: TileValue): TileTheme {
+  const known = TIER_THEMES[value];
+  if (known !== undefined) return known;
+  if (value > 8192) return highTierTheme(value);
+  return {
+    fill: '#3a3f55',
+    shine: '#6a7090',
+    glow: 'rgba(120,130,170,0.4)',
+    text: '#eef0fa',
+    aura: '#6a7090',
+  };
+}
+
+/**
+ * Compact-format a tile value for display:
+ *   < 10000  → as-is ("8192")
+ *   < 1e6    → "16K", "131K"
+ *   < 1e9    → "1.0M", "131M"
+ *   < 1e12   → "2.1B"
+ *   else     → "1.2T" / "4.5Q"
+ * Prevents 8+ digit numbers from bleeding across tiles.
+ */
+export function formatTileValue(value: TileValue): string {
+  if (value < 10000) return String(value);
+  if (value < 1_000_000) return `${Math.round(value / 1000)}K`;
+  if (value < 1_000_000_000) return formatWithUnit(value, 1_000_000, 'M');
+  if (value < 1_000_000_000_000) return formatWithUnit(value, 1_000_000_000, 'B');
+  if (value < 1_000_000_000_000_000) return formatWithUnit(value, 1_000_000_000_000, 'T');
+  return formatWithUnit(value, 1_000_000_000_000_000, 'Q');
+}
+
+function formatWithUnit(value: number, unit: number, suffix: string): string {
+  const v = value / unit;
+  if (v >= 100) return `${Math.round(v)}${suffix}`;
+  if (v >= 10) return `${v.toFixed(1).replace(/\.0$/, '')}${suffix}`;
+  return `${v.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
+}
+
+/**
+ * Pick a font size that lets `text` fit in the tile width.
+ * Caller passes the canvas ctx so we can measure with the active font family.
+ */
+export function fitFontSize(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+  fontFamily: string,
+  weight = 700,
+  ceil = 28,
+  floor = 11,
+): number {
+  for (let size = ceil; size >= floor; size -= 1) {
+    ctx.font = `${weight} ${size}px ${fontFamily}`;
+    if (ctx.measureText(text).width <= maxWidth) return size;
+  }
+  return floor;
+}
+
+export const EASE = {
+  outCubic: (t: number): number => 1 - Math.pow(1 - t, 3),
+  outQuint: (t: number): number => 1 - Math.pow(1 - t, 5),
+  inCubic: (t: number): number => t * t * t,
+  inOutCubic: (t: number): number => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2),
+  outBack: (t: number, k = 1.70158): number => {
+    const c3 = k + 1;
+    return 1 + c3 * Math.pow(t - 1, 3) + k * Math.pow(t - 1, 2);
+  },
+  outElastic: (t: number): number => {
+    const c4 = (2 * Math.PI) / 3;
+    if (t === 0 || t === 1) return t;
+    return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1;
+  },
+} as const;
+
+export const DURATION = {
+  spawn: 360,
+  pop: 420,
+  burst: 540,
+  flash: 240,
+  shimmer: 900,
+  retirementPulse: 900,
+  conquest: 1800,
+  hudCount: 380,
+} as const;


### PR DESCRIPTION
## Summary

Major visual overhaul of the playable v1 UI. Game logic is untouched — every change lives in `src/ui/` (with cosmetic-only updates to the Tuning Console). The kernel and session emit the same events; the UI now reacts with a layered, RAF-driven renderer and an event-driven effect system.

- **Aesthetic** — "Lumen" direction: deep navy-violet field with grain, glassy board frame, tiles drawn as luminous crystals (4-pass: aura → gradient body → top shine → text shadow). Display font **Unbounded**, mono **DM Mono**.
- **Effects engine** (`src/ui/effects.ts`) — `EffectQueue` + RAF loop drives tile-spawn drop-in, tile-pop, particle bursts, shockwaves, flashes, screen pulses, retirement sweep, conquest confetti.
- **Event reactions** — `chain-resolved` → source bursts + result pop + flash + shockwave (+ screen pulse on chains of 4+); `tiles-spawned` → drop-in animation; `retirement-fired` → vertical sweep + screen pulse + banner; **tier conquest** detected by diffing retired-tile counts → confetti + banner once per tier (matches the Free Play → Friction → Cleanup → Conquest framing).
- **HUD** — 4-stat glassy grid with armed-state glow during chain, count-up flash on stat changes, tier-tinted glow on `maxTileEver`, milestone banner, redesigned game-over card.
- **Number formatting** — `formatTileValue()` compacts huge values (`131072 → "131K"`, `2147483648 → "2.1B"`); `fitFontSize()` shrinks to tile width; high-tier procedural palette extends past 8192. Canonical numbers preserved in `title` tooltips.
- **DPR-aware canvas** for retina sharpness; `input.ts` adjusted to keep hit detection in CSS-pixel coords.
- **Tuning Console** restyled (slide-in glass panel, pill buttons, Unbounded headers); structure and behavior unchanged.

## Files

| File | Change |
|---|---|
| `index.html` | Fonts (Unbounded + DM Mono), gradient backdrop, grain overlay, design tokens |
| `src/ui/theme.ts` | **new** — tier themes (incl. procedural high-tier), `formatTileValue`, `fitFontSize`, easing/duration tokens |
| `src/ui/geometry.ts` | **new** — TILE/GAP/RADIUS, hit detection, roundRect (avoids circular import) |
| `src/ui/effects.ts` | **new** — EffectQueue, particle/burst/shockwave/flash/sweep/confetti, tile-anim sampling |
| `src/ui/board.ts` | Rewritten layered renderer (passes for empty cells, auras, bodies, chain trail, preview, effects) |
| `src/ui/hud.ts` | New structure, count-up flashes, banner, conquest hooks, tooltip with canonical numbers |
| `src/ui/app.ts` | RAF loop, event-driven effects, conquest detection, DPR-aware canvas, restyled game-over modal |
| `src/ui/input.ts` | DPR-aware hit math |
| `src/tuning-console/console.ts` | Cosmetic restyle of injected CSS only — structure and logic unchanged |

## Test plan

- [ ] `npm run typecheck`, `npm run lint`, `npm run check-boundaries`, `npm test` — all green locally (203 tests pass)
- [ ] `npm run dev` — load `http://localhost:3000/`, drag a chain across same-value tiles
- [ ] Trigger a chain of length 4+ to verify the screen pulse + shockwave + result pop
- [ ] Forge a 256+ tile to verify the milestone banner; 1024+ shows "LEGENDARY"
- [ ] Use Tuning Console to set high `ruleK` and bigger weights for high tiles to race the spawn pool past 256 — verify retirement sweep + warning banner
- [ ] Clear all retired tiles of a tier → conquest confetti + "CONQUEST · 256" banner fires once
- [ ] Trigger game-over → modal fades in, scales up, stat reveal
- [ ] Verify huge numbers (8K+) render with K/M/B suffixes and don't overflow tile or HUD card; hover the HUD value to see canonical number
- [ ] Resize window / try mobile — touch input + responsive canvas still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
