### PR TITLE
fix(ui): crash on tiles >8192 + CHAIN display clearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .claude/
 coverage/
+playlogs/*.jsonl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,8 @@ CI runs a dependency boundary check on every push. Violations are build failures
 
 See `docs/engineering/ARCHITECTURE.md` §Branch Strategy for the full rules. Short version: cut from `develop`, PR back to `develop`, never push directly to `develop` or `main`. Evan promotes `develop → main`.
 
+**Branch naming:** always use `feat/<slug>` or `fix/<slug>` cut from `origin/develop`. **Never work on the auto-generated `claude/<...>` worktree branch** — that is just a scratch worktree; cut a real feature branch from it immediately before doing any work.
+
 **Off-limits branches — do not read or use as context:**
 - `archive/v1` — abandoned prototype, different codebase entirely
 

--- a/src/ui/input.ts
+++ b/src/ui/input.ts
@@ -87,6 +87,7 @@ export function attachInput(
   }
 
   function onCancel(): void {
+    if (!active) return; // pointercancel can fire after pointerup; ignore if already handled
     active = false;
     chain = [];
     callbacks.onChainCancel();

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -37,24 +37,52 @@ export const VALID_NEXT_GLOW = 'rgba(180, 255, 200, 0.95)';
 export const CHAIN_TRAIL_HEAD = 'rgba(255, 255, 255, 1)';
 export const CHAIN_TRAIL_TAIL = 'rgba(180, 220, 255, 0.15)';
 
+function hslToHex(h: number, s: number, l: number): string {
+  const sl = s / 100;
+  const ll = l / 100;
+  const c = (1 - Math.abs(2 * ll - 1)) * sl;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = ll - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60)       { r = c; g = x; b = 0; }
+  else if (h < 120) { r = x; g = c; b = 0; }
+  else if (h < 180) { r = 0; g = c; b = x; }
+  else if (h < 240) { r = 0; g = x; b = c; }
+  else if (h < 300) { r = x; g = 0; b = c; }
+  else              { r = c; g = 0; b = x; }
+  const toHex = (v: number): string => Math.round((v + m) * 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
 // Procedural palette for high tiers (>8192). Cycles hue, brightness ramps deeper
 // so successive tier conquests feel distinct without inventing 30+ hand-tuned colors.
 function highTierTheme(value: TileValue): TileTheme {
   const log = Math.log2(value);
-  // Past 8192 (2^13) we cycle hue every ~6 tiers and rotate through 4 distinct families.
   const tierIndex = Math.floor(log) - 13;
   const family = tierIndex % 4;
   const hue = (tierIndex * 47) % 360;
   const sat = 70;
   const light = 52 - Math.min(20, tierIndex * 1.6);
-  const fillH = hue;
   const shineH = (hue + 18) % 360;
-  const fill = `hsl(${fillH}, ${sat}%, ${Math.max(28, light)}%)`;
-  const shine = `hsl(${shineH}, ${sat}%, ${Math.min(78, light + 30)}%)`;
-  const aura = `hsl(${shineH}, ${sat}%, ${Math.min(72, light + 22)}%)`;
-  const glow = `hsla(${shineH}, ${sat}%, ${Math.min(72, light + 22)}%, 0.7)`;
+  const fillL = Math.max(28, light);
+  const shineL = Math.min(78, light + 30);
+  const auraL = Math.min(72, light + 22);
+  const fill = hslToHex(hue, sat, fillL);
+  const shine = hslToHex(shineH, sat, shineL);
+  const aura = hslToHex(shineH, sat, auraL);
+  const { r, g, b } = hexToRgbComponents(aura);
+  const glow = `rgba(${r},${g},${b},0.7)`;
   const text = family === 0 || family === 2 ? '#0c0814' : '#fff7e8';
   return { fill, shine, glow, text, aura };
+}
+
+function hexToRgbComponents(hex: string): { r: number; g: number; b: number } {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
 }
 
 export function tileTheme(value: TileValue): TileTheme {


### PR DESCRIPTION
## What broke

**Bug 1 — Game crash on first 16K+ tile (the showstopper)**

PR #32 (luminous-crystal redesign) added `highTierTheme()` for tiles above 8192. It returned `hsl(...)` strings for `fill`, `shine`, and `aura`. Two downstream utilities — `hexToRgba()` and `mixColor()` — both assume `#rrggbb` hex input. Feeding them an HSL string produced `rgba(NaN, NaN, NaN, 0.45)`. Chrome throws `"could not be parsed as a color"` on `gradient.addColorStop()`, which killed the RAF loop and froze the game.

Confirmed from playlog `2026-05-03T11-17-56.jsonl`: crash on turn 52, the exact turn that produced the first 16384 tile and fired retirement.

**Bug 2 — CHAIN stat clearing to "—" after every committed chain**

`onCancel` in `input.ts` had no guard on `active`. Some browsers (especially touch/iOS) fire `pointercancel` immediately after `pointerup`. Since `onUp` already set `active = false` and dispatched the chain, the spurious `pointercancel` triggered `onChainCancel()` which reset the CHAIN display to "—" on every move.

## Fix

- **`src/ui/theme.ts`**: Added `hslToHex()`. `highTierTheme()` now returns `#rrggbb` hex for all fields — `hexToRgba` and `mixColor` never see HSL strings.
- **`src/ui/input.ts`**: Added `if (!active) return;` guard to `onCancel`. Spurious `pointercancel` after `pointerup` is silently ignored.

## Verification

Confirmed in-browser that the old path produces `rgba(NaN,NaN,101,0.45)` and throws exactly as observed. After fix, `hslToHex` produces valid hex and canvas gradient accepts it without error. No console errors on page load.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
