### PR TITLE
fix(ui): dead-zone prevents diagonal swipes from selecting wrong tile

### DIFF
--- a/src/ui/geometry.ts
+++ b/src/ui/geometry.ts
@@ -25,8 +25,10 @@ export function pixelToCell(
   y: number,
   rows: number,
   cols: number,
+  maxDist?: number,
 ): Cell | null {
   if (rows === 0 || cols === 0) return null;
+  const maxDistSq = maxDist !== undefined ? maxDist * maxDist : Infinity;
   let best: Cell | null = null;
   let bestDist = Infinity;
   for (let r = 0; r < rows; r++) {
@@ -40,6 +42,7 @@ export function pixelToCell(
       }
     }
   }
+  if (maxDist !== undefined && bestDist > maxDistSq) return null;
   return best;
 }
 

--- a/src/ui/input.ts
+++ b/src/ui/input.ts
@@ -1,5 +1,5 @@
 import type { Cell } from '../game-session/index.js';
-import { pixelToCell } from './board.js';
+import { pixelToCell, TILE } from './board.js';
 
 export interface InputCallbacks {
   onChainUpdate: (chain: readonly Cell[]) => void;
@@ -24,7 +24,7 @@ export function attachInput(
   let active = false;
   let chain: Cell[] = [];
 
-  function getCell(e: PointerEvent): Cell | null {
+  function getCell(e: PointerEvent, maxDist?: number): Cell | null {
     const rect = canvas.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
     // canvas.width is in device pixels (W * dpr); rect.width is CSS pixels.
@@ -33,7 +33,7 @@ export function attachInput(
     const scaleY = (canvas.height / rect.height) / dpr;
     const x = (e.clientX - rect.left) * scaleX;
     const y = (e.clientY - rect.top) * scaleY;
-    return pixelToCell(x, y, rows, cols);
+    return pixelToCell(x, y, rows, cols, maxDist);
   }
 
   function onDown(e: PointerEvent): void {
@@ -51,7 +51,10 @@ export function attachInput(
   function onMove(e: PointerEvent): void {
     if (!active) return;
     e.preventDefault();
-    const cell = getCell(e);
+    // When extending, require the pointer to be within half a tile of the cell center.
+    // A fast diagonal swipe can briefly make the wrong adjacent cell the nearest; this
+    // dead-zone around each cell boundary prevents that intermediate cell from being added.
+    const cell = getCell(e, chain.length > 0 ? TILE * 0.5 : undefined);
     if (cell === null) return;
 
     const last = chain[chain.length - 1];


### PR DESCRIPTION
## Summary

- `pixelToCell` uses nearest-center, so a fast diagonal swipe can briefly make an adjacent non-diagonal cell the nearest — that cell gets inserted into the chain before the intended diagonal neighbor
- Added optional `maxDist` parameter to `pixelToCell` (geometry.ts): rejects the best-match cell if it's farther than the threshold
- During chain extension (`onMove`), passes `TILE * 0.5` (38 px) as `maxDist` — the pointer must be solidly inside a tile's center zone before it registers
- Pointer-down (starting a chain) is unaffected — still uses unrestricted nearest-center for maximum tap precision

**Why half-tile radius works:** the Voronoi boundary between two adjacent cells is at the midpoint (~41 px from each center). The off-axis intermediate cell on a diagonal swipe sits ≈53 px away from the path — well outside the 38 px threshold — so it never fires.

## Test plan
- [ ] Drag diagonally across several tiles in quick succession — chain should skip straight to the diagonal neighbor, not pick up the axis-aligned intermediate
- [ ] Straight horizontal/vertical swipes still register cleanly
- [ ] Backtracking (sliding back over an earlier tile) still works
- [ ] Tap to start a chain still registers even near tile edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
