### PR TITLE
docs(claude): sync CLAUDE.md + FOLDER_STRUCTURE.md with Phase 5.5 reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 Chain Game is a browser-based 2D number-merging puzzle game with a path-chain mechanic; the design is complete and the engineering team is now building it in phases, starting with the pure game-logic kernel.
 
-**Current phase:** Phase 3 (Tuning Console) — kernel and playable v1 are complete, Tuning Console is next.
+**Current phase:** Phase 5.5 (Design Lab). Phases 0–5 are complete (kernel, playable v1, Tuning Console, retirement, simulation harness). Design-lab tooling is in place; broad matrix runs, `strategicHumanLike` refinement, and target-config selection are the active work. See `docs/engineering/PHASE_5_5_REQUIREMENTS.md` and `docs/engineering/PHASE_5_5_FINDINGS.md`.
 
 ---
 
@@ -62,31 +62,43 @@ chain-game/
 │       ├── FOLDER_STRUCTURE.md           ← canonical path map with ownership
 │       ├── PARAMETER_TIERS.md            ← which parameters are Tier 1/2/3
 │       ├── SIM_HARNESS_SCHEMA.md         ← simulation output schema
-│       ├── RETIREMENT_DESIGN_NOTES.md    ← created when Phase 4 lands
+│       ├── RETIREMENT_DESIGN_NOTES.md    ← Phase 4 retirement implementation notes
+│       ├── PHASE_5_5_REQUIREMENTS.md     ← Phase 5.5 design-lab scope
+│       ├── PHASE_5_5_FINDINGS.md         ← Phase 5.5 smoke results
 │       ├── session-briefs/               ← per-agent task context files
 │       ├── playtests/                    ← Evan's playtest notes
+│       ├── puzzles/                      ← canned board scenarios for replay/study
+│       ├── studies/                      ← multi-pass design investigations
 │       └── adr/                          ← Architecture Decision Records
 │           ├── 0000-tech-stack.md
-│           └── 0001-pure-kernel-module.md
+│           ├── 0001-pure-kernel-module.md
+│           └── 0002-session-update-config.md
 │
 ├── src/
 │   ├── game-kernel/          ← Game Logic Agent owns
-│   │   ├── index.ts          ← PUBLIC API ONLY (re-exports, no logic here)
+│   │   ├── index.ts          ← PUBLIC API (re-exports + applyAction orchestration)
 │   │   ├── types.ts          ← ALL GameState / Action / Config types
 │   │   ├── chain.ts          ← chain validation + resolution
 │   │   ├── board.ts          ← grid ops, gravity, tile spawn
 │   │   ├── rules.ts          ← Rule D k=2 implementation
-│   │   └── retirement.ts     ← stub in Phase 1; fully implemented in Phase 4
+│   │   ├── retirement.ts     ← retirement trigger detection + spawn-pool advancement
+│   │   └── values.ts         ← TileValue helpers (next/previous/range iteration)
 │   │
 │   ├── game-session/         ← Game Logic Agent owns
+│   │   ├── index.ts          ← public re-exports
 │   │   ├── session.ts        ← wraps kernel calls, maintains session state, emits events
-│   │   └── events.ts         ← event type definitions
+│   │   ├── events.ts         ← event type definitions
+│   │   └── playlog.ts        ← per-turn playlog recorder for fit-weights / replay
 │   │
 │   ├── ui/                   ← UI Agent owns
 │   │   ├── app.ts
 │   │   ├── board.ts
 │   │   ├── input.ts          ← MUST be a distinct module (swappable mouse/touch)
-│   │   └── hud.ts
+│   │   ├── hud.ts
+│   │   ├── effects.ts        ← screen pulse / merge burst / conquest celebration
+│   │   ├── geometry.ts       ← canvas grid math
+│   │   ├── playlog-controls.ts ← UI for playlog download
+│   │   └── theme.ts          ← color tokens for tile tiers
 │   │
 │   ├── tuning-console/       ← UI Agent owns
 │   │   ├── console.ts
@@ -94,19 +106,28 @@ chain-game/
 │   │   └── config-export.ts
 │   │
 │   └── sim-harness/          ← Simulation Agent owns
+│       ├── index.ts          ← public re-exports
 │       ├── runner.ts
 │       ├── sweep.ts
+│       ├── batch.ts          ← matrix runner for design-lab profiles
+│       ├── profiles.ts       ← named experiment configs
+│       ├── scoring.ts        ← target-distance scoring + candidate labels
 │       ├── analyzer.ts
 │       ├── types.ts
 │       └── strategies/
 │           ├── random.ts
 │           ├── greedy.ts
-│           └── heuristic.ts
+│           ├── heuristic.ts
+│           ├── weighted-heuristic.ts
+│           ├── long-chain.ts          ← longRandomWalk / longGreedyWalk / milestonePush
+│           ├── archetypes.ts          ← strategicHumanLike + research archetypes
+│           └── common.ts              ← shared candidate enumeration + helpers
 │
 └── tests/                    ← Test Agent owns
     ├── game-kernel/
     ├── game-session/
-    └── sim-harness/
+    ├── sim-harness/
+    └── tuning-console/
 ```
 
 ---
@@ -190,7 +211,7 @@ When you hit an ambiguity not covered by the spec:
 
 **Phase 1 — game-kernel** ✅ COMPLETE (2026-04-28)
 - All T1-T8b test vectors pass
-- ≥93% line/100% function coverage on `src/game-kernel/`
+- 100% line/function coverage gate on `src/game-kernel/`
 - Property tests: valid chain always returns power-of-2
 - Kernel source confirmed by Evan
 - Zero imports outside `src/game-kernel/`
@@ -203,16 +224,29 @@ When you hit an ambiguity not covered by the spec:
 - Zero game logic in UI layer (CI boundary check passes)
 
 **Phase 3 — Tuning Console** ✅ COMPLETE (2026-04-28, UAT passed)
-
 - [x] All Tier 1 parameters exposed (k, spawn weights per tier)
 - [x] Changing k mid-game produces correct results on next chain
 - [x] Config exportable as JSON
 - [x] Evan UAT passed
 
-Also delivered:
-- `docs/engineering/PARAMETER_TIERS.md`
-- ADR 0002 — `GameSession.updateConfig` Tier 1/2 contract
-- Backfilled `tests/game-session/` Phase 2 deferred suite (18 tests, 100% coverage)
+Also delivered: `docs/engineering/PARAMETER_TIERS.md`; ADR 0002 — `GameSession.updateConfig` Tier 1/2 contract; backfilled `tests/game-session/` deferred suite.
+
+**Phase 4 — Retirement** ✅ COMPLETE
+- Retirement trigger detection and spawn-pool advancement implemented in `src/game-kernel/retirement.ts`
+- Lifecycle framing (Free Play → Friction → Cleanup → Conquest) reflected in code and UI
+- See `docs/engineering/RETIREMENT_DESIGN_NOTES.md`
+
+**Phase 5 — Simulation Harness** ✅ COMPLETE
+- Headless runner, sweep, analyzer, and strategy ladder (random, greedy, heuristic, weighted-heuristic, long-chain, archetypes/strategicHumanLike) shipped under `src/sim-harness/`
+- 8.4× sweep speedup landed before tooling expansion (kernel + harness perf pass)
+- Output schema in `docs/engineering/SIM_HARNESS_SCHEMA.md`
+
+**Phase 5.5 — Design Lab** 🟡 IN PROGRESS
+- Tooling: experiment profiles, target scoring, batch runner, candidate labels, and replay-seed capture all in place
+- Smoke pass complete; broad 12-profile sweep timed out — runtime optimization needed
+- Open work: refine `strategicHumanLike` recovery dominance, run the full coarse sweep, then skill-curve comparison
+- Decision outputs (per `PHASE_5_5_REQUIREMENTS.md`): tune existing knobs / change a kernel rule / add companion pressure mechanic / accept Endless as forgiving
+- See `docs/engineering/PHASE_5_5_REQUIREMENTS.md` and `PHASE_5_5_FINDINGS.md`
 
 See `docs/engineering/ARCHITECTURE.md` for full phase sequence.
 

--- a/docs/engineering/FOLDER_STRUCTURE.md
+++ b/docs/engineering/FOLDER_STRUCTURE.md
@@ -43,7 +43,9 @@ Agents read these files. Agents never write to them.
 | `FOLDER_STRUCTURE.md` | This file |
 | `PARAMETER_TIERS.md` | Tier 1/2/3 parameter assignments for Tuning Console (Phase 3) |
 | `SIM_HARNESS_SCHEMA.md` | Simulation output schema (Evan-approved; design before Phase 5 runner) |
-| `RETIREMENT_DESIGN_NOTES.md` | Created during Phase 4 — any spec deviations noted here |
+| `RETIREMENT_DESIGN_NOTES.md` | Phase 4 retirement implementation notes; spec deviations noted here |
+| `PHASE_5_5_REQUIREMENTS.md` | Phase 5.5 design-lab scope and acceptance criteria |
+| `PHASE_5_5_FINDINGS.md` | Phase 5.5 smoke results and follow-up actions |
 
 ### `docs/engineering/session-briefs/`
 
@@ -56,6 +58,14 @@ Every agent session starts with the relevant brief from this directory.
 Evan's playtest notes. Naming: `YYYY-MM-DD-v[version].md`
 Created after every play session. Informs design gap protocols and ADR revisit triggers.
 
+### `docs/engineering/puzzles/`
+
+Canned board scenarios used as regression fixtures and study seeds.
+
+### `docs/engineering/studies/`
+
+Multi-pass design investigations (e.g. substrate audit, death-mechanism). Each study has its own writeup; results may feed PHASE_*_FINDINGS or future ADRs.
+
 ### `docs/engineering/adr/`
 
 Architecture Decision Records. Naming: `NNNN-short-title.md` (zero-padded 4 digits).
@@ -64,6 +74,7 @@ Architecture Decision Records. Naming: `NNNN-short-title.md` (zero-padded 4 digi
 |---|---|---|
 | `0000-tech-stack.md` | Accepted | 2026-04-28 |
 | `0001-pure-kernel-module.md` | Accepted | 2026-04-28 |
+| `0002-session-update-config.md` | Proposed (Evan approval pending) | 2026-04-28 |
 
 ---
 
@@ -75,17 +86,17 @@ The single source of truth for all game rules.
 
 | File | Purpose |
 |---|---|
-| `index.ts` | Public API — re-exports only. No logic in this file. |
+| `index.ts` | Public API — re-exports + `applyAction` orchestration |
 | `types.ts` | ALL `GameState`, `Action`, `Config`, `Event` types |
 | `chain.ts` | Chain validation (start rule, extension rule, adjacency) + chain resolution |
 | `board.ts` | Grid operations: `applyGravity`, `spawnTiles`, `setTile`, `removeTiles` |
 | `rules.ts` | Rule D k=2: `computeResultValue` |
-| `retirement.ts` | Retirement trigger detection and spawn pool advancement |
+| `retirement.ts` | Retirement trigger detection and spawn pool advancement (Phase 4) |
+| `values.ts` | TileValue helpers: `nextTileValue`, `previousTileValue`, range iteration |
 
 Constraints:
 - Zero imports from anywhere in `src/` — self-contained.
 - All functions are pure (see ADR-0001).
-- `retirement.ts` is a **stub** in Phase 1 (exports the correct signatures, throws `NotImplemented`). Fully implemented in Phase 4.
 
 ### `src/game-session/` — Game Logic Agent
 
@@ -93,8 +104,10 @@ Thin stateful wrapper around the kernel.
 
 | File | Purpose |
 |---|---|
+| `index.ts` | Public re-exports |
 | `session.ts` | Creates and manages a game session; calls `applyAction`; emits events |
 | `events.ts` | Session-level event type definitions (extends kernel events) |
+| `playlog.ts` | Per-turn playlog recorder — feeds `fit-weights` and replay flows |
 
 Constraints:
 - Imports from `game-kernel` only.
@@ -110,6 +123,10 @@ Rendering and input only. Never computes game logic.
 | `board.ts` | Canvas-based board renderer |
 | `input.ts` | Chain input handler (mouse drag / touch path) — MUST be a distinct module |
 | `hud.ts` | Score display, tile max, retirement milestone indicator |
+| `effects.ts` | Screen pulse, merge burst, conquest celebration animations |
+| `geometry.ts` | Canvas grid math (cell-to-pixel and hit testing) |
+| `playlog-controls.ts` | UI for downloading the per-turn playlog |
+| `theme.ts` | Color tokens for tile tiers and lifecycle phases |
 
 Constraints:
 - Imports from `game-session` only.
@@ -132,17 +149,25 @@ Constraints:
 
 ### `src/sim-harness/` — Simulation Agent
 
-Headless batch runner. Phase 5.
+Headless batch runner. Phase 5 + Phase 5.5 design lab.
 
 | File | Purpose |
 |---|---|
+| `index.ts` | Public re-exports |
 | `runner.ts` | Single-config runner: plays N games, returns results array |
 | `sweep.ts` | Parameter sweep: varies one config key across a range |
+| `batch.ts` | Matrix runner over named experiment profiles |
+| `profiles.ts` | Named experiment configs (`baselinePowerLaw`, `flat`, etc.) |
+| `scoring.ts` | Target-distance scoring + candidate labels (`promising`, `too-forgiving`, …) |
 | `analyzer.ts` | Statistics extraction from event logs |
 | `types.ts` | Output schema types — Evan-approved before runner code is written |
 | `strategies/random.ts` | Random-move strategy |
 | `strategies/greedy.ts` | Greedy strategy (highest immediate result) |
 | `strategies/heuristic.ts` | Heuristic strategy (designed-intent play) |
+| `strategies/weighted-heuristic.ts` | Heuristic with tunable feature weights (fit-weights output) |
+| `strategies/long-chain.ts` | Constructive long-chain strategies (`longRandomWalk`, `longGreedyWalk`, `milestonePush`) |
+| `strategies/archetypes.ts` | `strategicHumanLike` mode-switching strategy + research archetypes |
+| `strategies/common.ts` | Shared candidate enumeration and scoring helpers |
 
 Constraints:
 - Imports from `game-kernel` only.
@@ -156,9 +181,10 @@ Constraints:
 
 | Directory | Covers | Coverage requirement |
 |---|---|---|
-| `tests/game-kernel/` | All `src/game-kernel/` modules | **100%** |
+| `tests/game-kernel/` | All `src/game-kernel/` modules | **100%** (gate enforced in CI) |
 | `tests/game-session/` | `src/game-session/` | 90%+ |
 | `tests/sim-harness/` | `src/sim-harness/` | 80%+ |
+| `tests/tuning-console/` | `src/tuning-console/` | covers config-export round-trips |
 
 Test file naming: `[source-file-name].test.ts`
 


### PR DESCRIPTION
## Summary

The orientation docs (`CLAUDE.md` and `docs/engineering/FOLDER_STRUCTURE.md`) had drifted from the codebase. They still described the project as "Phase 3 next" while Phases 3, 4, 5, and 5.5 had all shipped on `develop`. The folder maps were missing real files; the ADR table was stale; `retirement.ts` was still described as a Phase-1 stub.

This PR only updates documentation to match what ships today on `develop`. No code changes, no workflow changes. The `develop → main` reconciliation and the branch-workflow rewrite are tracked separately.

## What changed

`CLAUDE.md`
- "Current phase" header rewritten from "Phase 3 next" to "Phase 5.5 (Design Lab) — Phases 0–5 complete; design-lab tooling in place; broad sweeps + `strategicHumanLike` refinement next."
- Folder map updated to include the files that actually exist on develop:
  - `src/game-kernel/values.ts`
  - `src/game-session/{index.ts, playlog.ts}`
  - `src/ui/{effects, geometry, playlog-controls, theme}.ts`
  - `src/sim-harness/{index, batch, profiles, scoring}.ts`
  - `src/sim-harness/strategies/{weighted-heuristic, long-chain, archetypes, common}.ts`
  - `tests/tuning-console/`
  - `docs/engineering/{PHASE_5_5_REQUIREMENTS, PHASE_5_5_FINDINGS, puzzles/, studies/}`
  - ADR `0002-session-update-config.md`
- Phase status section adds explicit Phase 4, Phase 5, and Phase 5.5 entries with their actual gate status.
- Removed stale "stub in Phase 1" language for `retirement.ts`.
- Updated kernel coverage line to match the gate that actually runs (100% line/function via `check-kernel-coverage.js`).

`docs/engineering/FOLDER_STRUCTURE.md`
- Same omissions corrected in module tables.
- ADR table now includes 0002.
- New rows for `puzzles/` and `studies/` subdirectories.
- Removed Phase-1-stub language; updated retirement.ts row to reflect Phase 4 implementation.
- Tests table adds a `tests/tuning-console/` row.

## What this PR does NOT change

- The "Branch Workflow" section in CLAUDE.md still describes `develop → main`. The collapse to single-trunk is a separate PR.
- `.github/workflows/ci.yml` is untouched.
- No code, no game logic, no public API.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run check-boundaries` — clean
- [ ] Evan reads through and confirms folder-map and Phase 5.5 framing match intent before merge (CLAUDE.md is in the Evan-approval set)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrbKknaqr7wcPAPUGJFTH2)_