### PR TITLE
docs(arch): update ARCHITECTURE.md Branch Strategy to single-trunk (PR #41 followup)

### DIFF
--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -95,20 +95,25 @@ This verbosity is intentional. The Simulation Harness needs full state snapshots
 
 ## Branch Strategy
 
+Single-trunk model. `main` is the only long-lived branch.
+
 ```
-main              ← protected; Evan-only merge; deploys to production
-  └── develop     ← integration branch; all agent PRs target this
-        ├── feat/kernel-phase1
-        ├── feat/ui-phase2
-        ├── feat/tests-phase1
-        ├── feat/sim-harness
-        └── fix/[issue-number]-[description]
+main              ← protected; integration branch; deploys to production
+  ├── feat/<slug>          ← new features
+  ├── fix/<slug>           ← bug fixes
+  ├── docs/<slug>          ← documentation changes
+  ├── chore/<slug>         ← maintenance / refactors
+  └── arch/<slug>          ← architectural / cross-cutting work
 ```
 
 Rules:
-- All feature branches are cut from `develop`, never from another feature branch.
-- Agents never push directly to `develop` or `main`.
-- Every task lands in a PR. No direct commits.
+- Every change is cut from `origin/main` and PR'd back to `main`.
+- Branches are never cut from another feature branch.
+- Direct pushes to `main` are blocked by branch protection. Every change lands via a reviewed, CI-green PR.
+- Squash-merge is the standard merge style.
+- Branch names use `<type>/<short-slug>` form. Never work on the auto-generated `claude/<...>` worktree branch — cut a real feature branch from it before doing any work.
+
+> Historical note: prior to 2026-05-05 this project used a `develop` integration branch (`feat/* → develop → main`). It was collapsed into a single-trunk model with `main` as the integration branch in PR #41. References to `develop` in older session briefs and ADRs reflect that earlier workflow.
 
 ---
 


### PR DESCRIPTION
## Summary

Cleanup follow-up to PR #41. The `Branch Strategy` section in `docs/engineering/ARCHITECTURE.md` still described the prior `feat/* → develop → main` flow. This PR brings it in line with `CLAUDE.md`'s single-trunk language so the two engineering docs don't contradict each other for any future agent or contributor reading top-to-bottom.

**Should have been folded into PR #41's workflow paperwork commit. My miss.**

## What changed

`docs/engineering/ARCHITECTURE.md` lines 96-112 — `## Branch Strategy` section:

- Tree diagram now shows `main` as the only long-lived branch with `feat/`, `fix/`, `docs/`, `chore/`, `arch/` slug branches as direct children.
- Rules updated: cut from `origin/main`, PR back to `main`, branch protection blocks direct pushes, squash-merge standard.
- Added the same historical note CLAUDE.md got — pointing at PR #41 as the transition point and explaining that `develop` references in older docs reflect the earlier flow.

No code, no game logic, no public API.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run check-boundaries` clean
- [ ] Evan reads the new section and confirms it matches intent

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrbKknaqr7wcPAPUGJFTH2)_