### PR TITLE
fix(kernel): persist spawnWeights across retirements; guard ruleK=0

### DIFF
--- a/src/game-kernel/index.ts
+++ b/src/game-kernel/index.ts
@@ -170,6 +170,7 @@ export function createGame(config: GameConfig): GameState {
     maxTileEver: 0 as TileValue,
     spawnPoolMin: config.spawnPoolMin,
     spawnPoolMax: config.spawnPoolMax,
+    spawnWeights: config.spawnWeights,
     prngState,
     events: [],
   };
@@ -355,6 +356,9 @@ export function applyAction(state: GameState, action: Action): GameState {
         ...state.config,
         spawnPoolMin: state.spawnPoolMin,
         spawnPoolMax: state.spawnPoolMax,
+        // Merge: persisted high-tier weights from previous retirements, with live
+        // config weights on top so tuning console updates take effect immediately.
+        spawnWeights: { ...state.spawnWeights, ...state.config.spawnWeights },
       };
       let newSpawnPoolMin = state.spawnPoolMin;
       let newSpawnPoolMax = state.spawnPoolMax;
@@ -422,6 +426,7 @@ export function applyAction(state: GameState, action: Action): GameState {
         maxTileEver: newMaxTileEver,
         spawnPoolMin: newSpawnPoolMin,
         spawnPoolMax: newSpawnPoolMax,
+        spawnWeights: runtimeSpawnConfig.spawnWeights,
         prngState: newPrng,
         events: [...state.events, ...newEvents],
       };

--- a/src/game-kernel/rules.ts
+++ b/src/game-kernel/rules.ts
@@ -16,7 +16,8 @@ export function computeResultValue(
   sameExtensions: number,
   config: Pick<GameConfig, 'ruleK'>
 ): TileValue {
-  const bonus = Math.floor(sameExtensions / config.ruleK);
+  const k = config.ruleK;
+  const bonus = k > 0 ? Math.min(Math.floor(sameExtensions / k), 40) : 0;
   const result = lastValue * 2 * Math.pow(2, bonus);
   return result;
 }

--- a/src/game-kernel/types.ts
+++ b/src/game-kernel/types.ts
@@ -68,6 +68,8 @@ export interface GameState {
   readonly spawnPoolMin: TileValue;
   /** Current spawn pool max (advances when retirement fires). */
   readonly spawnPoolMax: TileValue;
+  /** Accumulated spawn weights — persists high-tier weights added by retirement. */
+  readonly spawnWeights: Readonly<Partial<Record<TileValue, number>>>;
   /** PRNG state at this moment — deterministic, restorable. */
   readonly prngState: number;
   /** Accumulated event log for this game (used by sim harness). */

--- a/src/tuning-console/console.ts
+++ b/src/tuning-console/console.ts
@@ -260,7 +260,7 @@ export function mountTuningConsole(opts: TuningConsoleOpts): TuningConsoleHandle
   const ruleKSlider = makeSlider({
     id: 'tc-rulek',
     label: 'Rule D · k',
-    min: 0,
+    min: 1,
     max: 8,
     step: 1,
     value: initialConfig.ruleK,

--- a/tests/game-kernel/rules.test.ts
+++ b/tests/game-kernel/rules.test.ts
@@ -91,6 +91,14 @@ describe('computeChainResult — mandatory T1-T8b spec vectors', () => {
   });
 });
 
+describe('computeChainResult — ruleK edge cases', () => {
+  it('ruleK=0 never divides by zero — result is lastValue × 2', () => {
+    const cfg: GameConfig = { ...DEFAULT_CONFIG, ruleK: 0 };
+    const { board, chain } = chainFromValues([2, 2, 2, 2, 2, 2]);
+    expect(computeChainResult(board, chain, cfg)).toBe(4);
+  });
+});
+
 describe('computeChainResult — property tests', () => {
   it('always returns a power of 2', () => {
     const isPowerOf2 = (n: number): boolean => n > 0 && (n & (n - 1)) === 0;


### PR DESCRIPTION
## Summary

- **spawnWeights persistence**: high-tier weights added during retirement events now survive across turns instead of resetting each commit; tuning console overrides still apply immediately via a live-merge
- **ruleK=0 guard**: `computeResultValue` was dividing by zero when ruleK=0; now returns 0 bonus and caps multiplier at 40 to prevent runaway tile values
- **Rule D slider**: min raised 0→1 in tuning console to match

## Test plan
- [ ] Play to multiple retirements — spawn weights accumulate correctly
- [ ] Set Rule D k=0 in tuning console — no crash, no runaway tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)